### PR TITLE
Add an .app version for MacOs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Note: The results will take at least 3 minutes to appear, even if you add only o
 
 Note: for MacOS the docker command should not work. **HELP REQUIRED**
 
+You can download a MacOs App version here: https://github.com/melogabriel/google-maps-scraper/releases/tag/MacOs-v1.0.0 
+
 
 ### Command line:
 


### PR DESCRIPTION
I've created a .app version for MacOs that works in a similar way to the Windows binary. So that Mac users have an alternative to the problematic version with docker. 

I've added a link to the .dmg file in my fork but you can download and launch it within your releases and update the link.

I hope I've contributed in some way.

Thank you.