### PR TITLE
Optimize the parsing logic in place.go

### DIFF
--- a/gmaps/place.go
+++ b/gmaps/place.go
@@ -224,14 +224,11 @@ function parse() {
 	if (!appState) {
 		return null;
 	}
-
-	for (let i = 65; i <= 90; i++) {
-		const key = String.fromCharCode(i) + "f";
-		if (appState[key] && appState[key][6]) {
+	const keys = Object.keys(appState);
+	const key = keys[0];
+	if (appState[key] && appState[key][6]) {
 		return appState[key][6];
-		}
 	}
-
 	return null;
 }
 `


### PR DESCRIPTION
Perhaps for the purpose of anti-scraping, Google Maps changes the key name of `window.APP_INITIALIZATION_STATE[3]`. Previously, the code used a fixed pattern to match the key name. Now, it has been modified to directly read the returned key name, in order to adapt to Google Maps' irregular naming conventions.