### PR TITLE
Cleaned website

### DIFF
--- a/gmaps/entry.go
+++ b/gmaps/entry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"iter"
 	"math"
+	"net/url"
 	"runtime/debug"
 	"slices"
 	"strconv"
@@ -315,6 +316,11 @@ func EntryFromJSON(raw []byte, reviewCountOnly ...bool) (entry Entry, err error)
 	entry.OpenHours = getHours(darray)
 	entry.PopularTimes = getPopularTimes(darray)
 	entry.WebSite = getNthElementAndCast[string](darray, 7, 0)
+	// Clean Google redirect URL
+	if entry.WebSite != "" {
+		cleanURL, _ := extractActualURL(entry.WebSite)
+		entry.WebSite = cleanURL
+	}
 	entry.Phone = getNthElementAndCast[string](darray, 178, 0, 0)
 	entry.PlusCode = getNthElementAndCast[string](darray, 183, 2, 2, 0)
 	entry.ReviewRating = getNthElementAndCast[float64](darray, 4, 7)
@@ -680,6 +686,28 @@ func decodeURL(url string) (string, error) {
 	}
 
 	return unquoted, nil
+}
+
+// extractActualURL cleans URLs that Google redirects using the path /url?q=<real_url>
+func extractActualURL(googleURL string) (string, error) {
+	// If it doesn't start with /url?q=, return as is
+	if !strings.HasPrefix(googleURL, "/url?q=") {
+		return googleURL, nil
+	}
+
+	// Parse the URL
+	parsedURL, err := url.Parse(googleURL)
+	if err != nil {
+		return googleURL, nil // Return original if parsing fails
+	}
+
+	// Extract the 'q' parameter that contains the real URL
+	actualURL := parsedURL.Query().Get("q")
+	if actualURL == "" {
+		return googleURL, nil // Return original if there's no 'q' parameter
+	}
+
+	return actualURL, nil
 }
 
 type EntryWithDistance struct {


### PR DESCRIPTION
### Summary

This PR adds a new helper function, `extractActualURL`, to correctly parse and clean website URLs returned by Google.

Previously, the scraper stored the raw redirect URL (for example `/url?q=<actual_url>`), which caused the email extraction logic to fail because the `WebSite` field did not contain a valid, clean URL.

The new logic extracts the real target URL before assigning it to `entry.WebSite`, ensuring that downstream processing (including email extraction) works as expected.

<img width="817" height="528" alt="image" src="https://github.com/user-attachments/assets/32db5a67-4577-44c3-9de9-a2b324e8c2b1" />

<img width="572" height="577" alt="image" src="https://github.com/user-attachments/assets/2333e2b9-a64e-490f-a9c8-87a51e22d2a5" />

### Details

- Added the function `extractActualURL` to handle Google redirect URLs.
- Applied URL cleaning during `EntryFromJSON` parsing.
- Ensures that websites are stored as valid, direct URLs.
- Fixes issues where email extraction failed due to unclean URLs.

