### PR TITLE
Extract place_id

### DIFF
--- a/gmaps/entry.go
+++ b/gmaps/entry.go
@@ -84,6 +84,7 @@ type Entry struct {
 	Timezone            string                 `json:"timezone"`
 	PriceRange          string                 `json:"price_range"`
 	DataID              string                 `json:"data_id"`
+	PlaceID             string                 `json:"place_id"`
 	Images              []Image                `json:"images"`
 	Reservations        []LinkSource           `json:"reservations"`
 	OrderOnline         []LinkSource           `json:"order_online"`
@@ -180,6 +181,7 @@ func (e *Entry) CsvHeaders() []string {
 		"timezone",
 		"price_range",
 		"data_id",
+		"place_id",
 		"images",
 		"reservations",
 		"order_online",
@@ -218,6 +220,7 @@ func (e *Entry) CsvRow() []string {
 		e.Timezone,
 		e.PriceRange,
 		e.DataID,
+		e.PlaceID,
 		stringify(e.Images),
 		stringify(e.Reservations),
 		stringify(e.OrderOnline),
@@ -341,6 +344,7 @@ func EntryFromJSON(raw []byte, reviewCountOnly ...bool) (entry Entry, err error)
 	entry.Timezone = getNthElementAndCast[string](darray, 30)
 	entry.PriceRange = getNthElementAndCast[string](darray, 4, 2)
 	entry.DataID = getNthElementAndCast[string](darray, 10)
+	entry.PlaceID = getNthElementAndCast[string](darray, 78)
 
 	items := getLinkSource(getLinkSourceParams{
 		arr:    getNthElementAndCast[[]any](darray, 171, 0),

--- a/gmaps/entry_test.go
+++ b/gmaps/entry_test.go
@@ -55,6 +55,7 @@ func Test_EntryFromJSON(t *testing.T) {
 		Timezone:     "Asia/Nicosia",
 		PriceRange:   "€€",
 		DataID:       "0x14e732fd76f0d90d:0xe5415928d6702b47",
+		PlaceID:      "ChIJDdnwdv0y5xQRRytw1ihZQeU",
 		Images: []gmaps.Image{
 			{
 				Title: "All",


### PR DESCRIPTION
Fixes https://github.com/gosom/google-maps-scraper/issues/186

## Summary

  - Adds extraction of Google's place_id field from scraped place data

##  Changes

  - Added PlaceID field to the Entry struct with JSON tag place_id
  - Extract the value from darray[78] in EntryFromJSON()
  - Added place_id column to CSV output
  - Updated test fixture with expected place_id value

##  Why

  The place_id is Google's stable unique identifier for a place (e.g., ChIJDdnwdv0y5xQRRytw1ihZQeU). Unlike cid or data_id, the place_id is:
  - Used directly in Google Maps APIs (Places API, Geocoding API)
  - Stable across Google Maps URL formats

This way, we can combine both API and scraper usage

##  Test plan

  - go build ./... passes
  - go test ./... passes