### PR TITLE
[update] added email filter

### DIFF
--- a/gmaps/place.go
+++ b/gmaps/place.go
@@ -21,6 +21,7 @@ type PlaceJob struct {
 	ExtractEmail        bool
 	ExitMonitor         exiter.Exiter
 	ExtractExtraReviews bool
+	EmailFilter         EmailFilter
 }
 
 func NewPlaceJob(parentID, langCode, u string, extractEmail, extraExtraReviews bool, opts ...PlaceJobOptions) *PlaceJob {
@@ -55,6 +56,12 @@ func NewPlaceJob(parentID, langCode, u string, extractEmail, extraExtraReviews b
 func WithPlaceJobExitMonitor(exitMonitor exiter.Exiter) PlaceJobOptions {
 	return func(j *PlaceJob) {
 		j.ExitMonitor = exitMonitor
+	}
+}
+
+func WithPlaceEmailFilter(filter EmailFilter) PlaceJobOptions {
+	return func(j *PlaceJob) {
+		j.EmailFilter = filter
 	}
 }
 
@@ -98,6 +105,10 @@ func (j *PlaceJob) Process(_ context.Context, resp *scrapemate.Response) (any, [
 		opts := []EmailExtractJobOptions{}
 		if j.ExitMonitor != nil {
 			opts = append(opts, WithEmailJobExitMonitor(j.ExitMonitor))
+		}
+
+		if j.EmailFilter != nil {
+			opts = append(opts, WithEmailFilter(j.EmailFilter))
 		}
 
 		emailJob := NewEmailJob(j.ID, &entry, opts...)


### PR DESCRIPTION
This PR introduces a dedicated email filtering mechanism to the scraping process.

In my experience using the scraper, I consistently find myself manually filtering out the same "bad" or irrelevant emails from the final results. To address this inefficiency, I've moved that logic directly into the codebase so the filtering happens automatically during the extraction phase.

Notes for Reviewers: I haven't had the chance to test this thoroughly yet, so please treat this as an initial implementation that needs review before approval. It serves as a starting point to improve the quality of email extraction and reduce manual cleanup.