### PR TITLE
fix: Return direct image URLs instead of moderation links in user reviews

### DIFF
--- a/gmaps/entry.go
+++ b/gmaps/entry.go
@@ -525,16 +525,32 @@ func parseReviews(reviewsI []any) []Review {
 			continue
 		}
 
-		// Try multiple paths for images
-		optsI := getNthElementAndCast[[]any](el, 2, 2, 0, 1, 21, 7)
-		if len(optsI) == 0 {
-			optsI = getNthElementAndCast[[]any](el, 2, 2, 0, 1, 7)
+		// Try parsing the direct image URLs from their explicit paths
+		imagesI := getNthElementAndCast[[]any](el, 2, 2)
+		for j := range imagesI {
+			// Real image url is typically at p[1][6][0] for each photo element p in imagesI
+			url := getNthElementAndCast[string](imagesI, j, 1, 6, 0)
+			if url != "" {
+				review.Images = append(review.Images, url)
+			}
 		}
 
-		for j := range optsI {
-			val := getNthElementAndCast[string](optsI, j)
-			if val != "" && len(val) > 2 {
-				review.Images = append(review.Images, val[2:])
+		// Fallback to the original structure just in case there's legacy format
+		if len(review.Images) == 0 {
+			optsI := getNthElementAndCast[[]any](el, 2, 2, 0, 1, 21, 7)
+			if len(optsI) == 0 {
+				optsI = getNthElementAndCast[[]any](el, 2, 2, 0, 1, 7)
+			}
+
+			for j := range optsI {
+				val := getNthElementAndCast[string](optsI, j)
+				if val != "" && len(val) > 2 {
+					if strings.HasPrefix(val, "//") {
+						review.Images = append(review.Images, val[2:])
+					} else {
+						review.Images = append(review.Images, val)
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
### Problem                                                                                                                                                                                   
                                                                                                                                                                                              
  The `user_reviews.Images` field was returning Google Maps image moderation/reporting links instead of the actual image source URLs.                                                           
                                                                                                                                                                                                
  The previous implementation extracted image URLs from a path (`el[2][2][0][1][21][7]` or `el[2][2][0][1][7]`) that resolved to Google's internal image reporting links:

  www.google.com/local/imagery/report/?cb_client=maps_sv.tactile&image_key=!1e10...

  These links cannot be rendered in a UI since they point to a moderation flow, not the image itself.

  ### Solution

  Restructured the image parsing logic to extract URLs from the correct path in the response payload (`imagesI[j][1][6][0]`), which contains the direct Google-hosted image URLs:

  lh3.googleusercontent.com/...
  streetviewpixels-pa.googleapis.com/...

  The original fallback paths are preserved as a secondary attempt for legacy response formats. Additionally fixed a minor edge case where URLs starting with `//` were being sliced (`val[2:]`)
   unconditionally — now only protocol-relative URLs are trimmed, while fully-qualified URLs are passed through unchanged.

  ### Changes

  - **Primary**: iterate `el[2][2]` (photo list) and extract direct image URL at `[j][1][6][0]`
  - **Fallback**: retain original `el[2][2][0][1][21][7]` / `el[2][2][0][1][7]` paths when primary yields no results
  - **Fix**: unconditional `val[2:]` slice is now guarded by `strings.HasPrefix(val, "//")`