### PR TITLE
feat: add grid scraping to overcome Google Maps ~120 results limit

### DIFF
--- a/grid/grid.go
+++ b/grid/grid.go
@@ -1,0 +1,127 @@
+// Package grid provides utilities to divide a geographic bounding box into a
+// grid of smaller cells. This is useful for overcoming Google Maps' ~120
+// results-per-search limit: by splitting a large area into many small cells
+// and issuing one search per cell, you can retrieve far more results.
+package grid
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+const kmPerDegreeLat = 111.32
+
+// BoundingBox represents a geographic rectangle defined by two corners.
+type BoundingBox struct {
+	MinLat float64
+	MinLon float64
+	MaxLat float64
+	MaxLon float64
+}
+
+// ParseBoundingBox parses a string with format "minLat,minLon,maxLat,maxLon".
+// Example: "40.30,-3.80,40.50,-3.60"
+func ParseBoundingBox(s string) (BoundingBox, error) {
+	parts := strings.Split(s, ",")
+	if len(parts) != 4 {
+		return BoundingBox{}, fmt.Errorf("invalid bounding box %q: expected format minLat,minLon,maxLat,maxLon", s)
+	}
+
+	vals := make([]float64, 4)
+
+	for i, p := range parts {
+		v, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
+		if err != nil {
+			return BoundingBox{}, fmt.Errorf("invalid bounding box value %q: %w", p, err)
+		}
+
+		vals[i] = v
+	}
+
+	bbox := BoundingBox{
+		MinLat: vals[0],
+		MinLon: vals[1],
+		MaxLat: vals[2],
+		MaxLon: vals[3],
+	}
+
+	if bbox.MinLat >= bbox.MaxLat {
+		return BoundingBox{}, fmt.Errorf("minLat (%f) must be less than maxLat (%f)", bbox.MinLat, bbox.MaxLat)
+	}
+
+	if bbox.MinLon >= bbox.MaxLon {
+		return BoundingBox{}, fmt.Errorf("minLon (%f) must be less than maxLon (%f)", bbox.MinLon, bbox.MaxLon)
+	}
+
+	return bbox, nil
+}
+
+// Cell represents the center point of a grid cell.
+type Cell struct {
+	Lat float64
+	Lon float64
+}
+
+// GeoCoordinates returns the cell center in "lat,lon" format, ready to pass
+// to gmaps.NewGmapJob as the geoCoordinates parameter.
+func (c Cell) GeoCoordinates() string {
+	return fmt.Sprintf("%f,%f", c.Lat, c.Lon)
+}
+
+// GenerateCells divides bbox into a grid where each cell is approximately
+// cellSizeKm × cellSizeKm. It returns the center point of every cell.
+//
+// The longitude step is adjusted for the latitude of the bounding box centre
+// so that cells are roughly square on the ground.
+//
+// Example: a 20×20 km area with cellSizeKm=1 produces ~400 cells.
+func GenerateCells(bbox BoundingBox, cellSizeKm float64) []Cell {
+	if cellSizeKm <= 0 {
+		cellSizeKm = 1.0
+	}
+
+	// Latitude step is constant everywhere.
+	latStep := cellSizeKm / kmPerDegreeLat
+
+	// Longitude step varies with latitude; use the midpoint for a good estimate.
+	midLat := (bbox.MinLat + bbox.MaxLat) / 2
+	lonStep := cellSizeKm / (kmPerDegreeLat * math.Cos(midLat*math.Pi/180))
+
+	var cells []Cell
+
+	// Start at the centre of the first cell (half a step from the edge).
+	for lat := bbox.MinLat + latStep/2; lat < bbox.MaxLat; lat += latStep {
+		for lon := bbox.MinLon + lonStep/2; lon < bbox.MaxLon; lon += lonStep {
+			cells = append(cells, Cell{Lat: lat, Lon: lon})
+		}
+	}
+
+	return cells
+}
+
+// EstimateCellCount returns how many cells GenerateCells would produce
+// without allocating them. Useful for logging or validation.
+func EstimateCellCount(bbox BoundingBox, cellSizeKm float64) int {
+	if cellSizeKm <= 0 {
+		cellSizeKm = 1.0
+	}
+
+	latStep := cellSizeKm / kmPerDegreeLat
+	midLat := (bbox.MinLat + bbox.MaxLat) / 2
+	lonStep := cellSizeKm / (kmPerDegreeLat * math.Cos(midLat*math.Pi/180))
+
+	latCells := int(math.Ceil((bbox.MaxLat - bbox.MinLat) / latStep))
+	lonCells := int(math.Ceil((bbox.MaxLon - bbox.MinLon) / lonStep))
+
+	if latCells < 0 {
+		latCells = 0
+	}
+
+	if lonCells < 0 {
+		lonCells = 0
+	}
+
+	return latCells * lonCells
+}

--- a/runner/filerunner/filerunner.go
+++ b/runner/filerunner/filerunner.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gosom/google-maps-scraper/deduper"
 	"github.com/gosom/google-maps-scraper/exiter"
+	"github.com/gosom/google-maps-scraper/grid"
 	"github.com/gosom/google-maps-scraper/leadsdb"
 	"github.com/gosom/google-maps-scraper/runner"
 	"github.com/gosom/google-maps-scraper/tlmt"
@@ -76,19 +77,43 @@ func (r *fileRunner) Run(ctx context.Context) (err error) {
 	dedup := deduper.New()
 	exitMonitor := exiter.New()
 
-	seedJobs, err = runner.CreateSeedJobs(
-		r.cfg.FastMode,
-		r.cfg.LangCode,
-		r.input,
-		r.cfg.MaxDepth,
-		r.cfg.Email,
-		r.cfg.GeoCoordinates,
-		r.cfg.Zoom,
-		r.cfg.Radius,
-		dedup,
-		exitMonitor,
-		r.cfg.ExtraReviews,
-	)
+	if r.cfg.GridBBox != "" {
+		bbox, bboxErr := grid.ParseBoundingBox(r.cfg.GridBBox)
+		if bboxErr != nil {
+			return fmt.Errorf("invalid -grid-bbox: %w", bboxErr)
+		}
+
+		cellCount := grid.EstimateCellCount(bbox, r.cfg.GridCellKm)
+		fmt.Fprintf(os.Stderr, "grid scraping: ~%d cells (%.2f km each)\n", cellCount, r.cfg.GridCellKm)
+
+		seedJobs, err = runner.CreateGridSeedJobs(
+			r.cfg.LangCode,
+			r.input,
+			r.cfg.MaxDepth,
+			r.cfg.Email,
+			bbox,
+			r.cfg.GridCellKm,
+			r.cfg.Zoom,
+			dedup,
+			exitMonitor,
+			r.cfg.ExtraReviews,
+		)
+	} else {
+		seedJobs, err = runner.CreateSeedJobs(
+			r.cfg.FastMode,
+			r.cfg.LangCode,
+			r.input,
+			r.cfg.MaxDepth,
+			r.cfg.Email,
+			r.cfg.GeoCoordinates,
+			r.cfg.Zoom,
+			r.cfg.Radius,
+			dedup,
+			exitMonitor,
+			r.cfg.ExtraReviews,
+		)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/runner/jobs.go
+++ b/runner/jobs.go
@@ -10,9 +10,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/gosom/google-maps-scraper/deduper"
 	"github.com/gosom/google-maps-scraper/exiter"
 	"github.com/gosom/google-maps-scraper/gmaps"
+	"github.com/gosom/google-maps-scraper/grid"
 	"github.com/gosom/scrapemate"
 )
 
@@ -128,6 +130,117 @@ func CreateSeedJobs(
 	}
 
 	return jobs, scanner.Err()
+}
+
+// CreateGridSeedJobs reads search queries from r and produces one GmapJob per
+// (query, grid-cell) pair. Each cell covers approximately cellSizeKm × cellSizeKm
+// on the ground. The zoom level controls how much of the map Google Maps renders
+// per cell (use 14-16 for most cases).
+//
+// Deduplication across cells is handled automatically by the shared deduper.
+func CreateGridSeedJobs(
+	langCode string,
+	r io.Reader,
+	maxDepth int,
+	email bool,
+	bbox grid.BoundingBox,
+	cellSizeKm float64,
+	zoom int,
+	dedup deduper.Deduper,
+	exitMonitor exiter.Exiter,
+	extraReviews bool,
+) ([]scrapemate.IJob, error) {
+	cells := grid.GenerateCells(bbox, cellSizeKm)
+	if len(cells) == 0 {
+		return nil, fmt.Errorf("grid produced 0 cells — check bounding box and cell size")
+	}
+
+	queries, err := readQueries(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(queries) == 0 {
+		return nil, fmt.Errorf("no queries found in input")
+	}
+
+	var jobs []scrapemate.IJob
+
+	for _, q := range queries {
+		queryText := q.text
+		queryID := q.id
+
+		for _, cell := range cells {
+			// Each cell gets a unique ID derived from the query ID (or a new UUID).
+			cellID := uuid.New().String()
+			if queryID != "" {
+				cellID = fmt.Sprintf("%s-%s", queryID, cellID)
+			}
+
+			opts := []gmaps.GmapJobOptions{}
+
+			if dedup != nil {
+				opts = append(opts, gmaps.WithDeduper(dedup))
+			}
+
+			if exitMonitor != nil {
+				opts = append(opts, gmaps.WithExitMonitor(exitMonitor))
+			}
+
+			if extraReviews {
+				opts = append(opts, gmaps.WithExtraReviews())
+			}
+
+			job := gmaps.NewGmapJob(
+				cellID,
+				langCode,
+				queryText,
+				maxDepth,
+				email,
+				cell.GeoCoordinates(),
+				zoom,
+				opts...,
+			)
+
+			jobs = append(jobs, job)
+		}
+	}
+
+	return jobs, nil
+}
+
+// query holds a parsed input line.
+type query struct {
+	text string
+	id   string
+}
+
+// readQueries reads all non-empty lines from r and parses optional custom IDs
+// using the "#!#" delimiter (same format as CreateSeedJobs).
+func readQueries(r io.Reader) ([]query, error) {
+	var queries []query
+
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		q := query{}
+
+		if before, after, ok := strings.Cut(line, "#!#"); ok {
+			q.text = strings.TrimSpace(before)
+			q.id = strings.TrimSpace(after)
+		} else {
+			q.text = line
+		}
+
+		queries = append(queries, q)
+	}
+
+	return queries, scanner.Err()
 }
 
 func LoadCustomWriter(pluginDir, pluginName string) (scrapemate.ResultWriter, error) {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -80,6 +80,11 @@ type Config struct {
 	DisablePageReuse         bool
 	ExtraReviews             bool
 	LeadsDBAPIKey            string
+
+	// Grid scraping — divide a bounding box into cells to bypass the ~120
+	// results-per-search limit imposed by Google Maps.
+	GridBBox   string  // "minLat,minLon,maxLat,maxLon"
+	GridCellKm float64 // size of each grid cell in km (default: 1.0)
 }
 
 func ParseConfig() *Config {
@@ -127,6 +132,8 @@ func ParseConfig() *Config {
 	flag.BoolVar(&cfg.DisablePageReuse, "disable-page-reuse", false, "disable page reuse in playwright")
 	flag.BoolVar(&cfg.ExtraReviews, "extra-reviews", false, "enable extra reviews collection")
 	flag.StringVar(&cfg.LeadsDBAPIKey, "leadsdb-api-key", "", "LeadsDB API key for exporting results to LeadsDB")
+	flag.StringVar(&cfg.GridBBox, "grid-bbox", "", "bounding box for grid scraping: 'minLat,minLon,maxLat,maxLon' (e.g. '40.30,-3.80,40.50,-3.60')")
+	flag.Float64Var(&cfg.GridCellKm, "grid-cell", 1.0, "grid cell size in km [default: 1.0]. Use with -grid-bbox")
 
 	flag.Parse()
 


### PR DESCRIPTION
Introduces a new `grid` package and CLI flags that divide a geographic bounding box into a grid of smaller cells, issuing one search job per cell. This lets users scrape thousands of results from a large area by bypassing Google Maps' per-search cap.

New flags:
  -grid-bbox  "minLat,minLon,maxLat,maxLon"  e.g. "40.30,-3.80,40.50,-3.60"
  -grid-cell  <km>                             cell size in km (default 1.0)
  -zoom        reused to control the view per cell (default 15)

Results across overlapping cells are deduplicated automatically via the existing place-ID deduper.