### PR TITLE
Feature/grid scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ Location Settings:
   -geo string        Coordinates for search, e.g., '37.7749,-122.4194'
   -zoom int          Zoom level 0-21 (default: 15)
   -radius float      Search radius in meters (default: 10000)
+  -grid-bbox string  Bounding box for grid scraping, format: "minLat,minLon,maxLat,maxLon"
+  -grid-cell float   Grid cell size in km (default: 1.0, used with -grid-bbox)
 
 Web Server:
   -web               Run web server mode
@@ -354,6 +356,10 @@ Advanced:
   -fast-mode                      Quick mode with reduced data
   -debug                          Show browser window
   -writer string                  Custom writer plugin (format: 'dir:pluginName')
+
+Notes:
+  -grid-bbox requires a valid zoom level (1-21)
+  -fast-mode cannot be used together with -grid-bbox
 ```
 
 Run `./google-maps-scraper -h` for the complete list.
@@ -408,6 +414,33 @@ Fast mode returns up to 21 results per query, ordered by distance. Useful for qu
 ```
 
 > **Warning:** Fast mode is in Beta. You may experience blocking.
+
+### Grid Scraping (BBox)
+
+Grid mode splits a bounding box into cells and runs one search per cell. This is useful when a single search does not return enough places.
+
+`queries.txt` example:
+
+```text
+cafes in Peristeri, Greece
+```
+
+Command example:
+
+```bash
+./google-maps-scraper \
+  -input queries.txt \
+  -results peristeri-cafes.csv \
+  -grid-bbox "38.0077,23.6719,38.0257,23.6947" \
+  -grid-cell 0.5 \
+  -zoom 16 \
+  -depth 1 \
+  -c 4
+```
+
+Notes:
+- `-grid-bbox` guides where searches are launched from, but results are not strictly clipped to the box.
+- For strict distance filtering, use `-fast-mode` with `-geo` + `-radius` (or post-filter by latitude/longitude).
 
 ---
 

--- a/grid/grid.go
+++ b/grid/grid.go
@@ -12,6 +12,7 @@ import (
 )
 
 const kmPerDegreeLat = 111.32
+const minCosLatitude = 1e-6
 
 // BoundingBox represents a geographic rectangle defined by two corners.
 type BoundingBox struct {
@@ -37,6 +38,10 @@ func ParseBoundingBox(s string) (BoundingBox, error) {
 			return BoundingBox{}, fmt.Errorf("invalid bounding box value %q: %w", p, err)
 		}
 
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return BoundingBox{}, fmt.Errorf("invalid bounding box value %q: must be finite", p)
+		}
+
 		vals[i] = v
 	}
 
@@ -53,6 +58,22 @@ func ParseBoundingBox(s string) (BoundingBox, error) {
 
 	if bbox.MinLon >= bbox.MaxLon {
 		return BoundingBox{}, fmt.Errorf("minLon (%f) must be less than maxLon (%f)", bbox.MinLon, bbox.MaxLon)
+	}
+
+	if bbox.MinLat < -90 || bbox.MinLat > 90 {
+		return BoundingBox{}, fmt.Errorf("minLat (%f) must be between -90 and 90", bbox.MinLat)
+	}
+
+	if bbox.MaxLat < -90 || bbox.MaxLat > 90 {
+		return BoundingBox{}, fmt.Errorf("maxLat (%f) must be between -90 and 90", bbox.MaxLat)
+	}
+
+	if bbox.MinLon < -180 || bbox.MinLon > 180 {
+		return BoundingBox{}, fmt.Errorf("minLon (%f) must be between -180 and 180", bbox.MinLon)
+	}
+
+	if bbox.MaxLon < -180 || bbox.MaxLon > 180 {
+		return BoundingBox{}, fmt.Errorf("maxLon (%f) must be between -180 and 180", bbox.MaxLon)
 	}
 
 	return bbox, nil
@@ -78,16 +99,13 @@ func (c Cell) GeoCoordinates() string {
 //
 // Example: a 20×20 km area with cellSizeKm=1 produces ~400 cells.
 func GenerateCells(bbox BoundingBox, cellSizeKm float64) []Cell {
-	if cellSizeKm <= 0 {
-		cellSizeKm = 1.0
-	}
+	cellSizeKm = normalizeCellSizeKm(cellSizeKm)
 
 	// Latitude step is constant everywhere.
 	latStep := cellSizeKm / kmPerDegreeLat
 
 	// Longitude step varies with latitude; use the midpoint for a good estimate.
-	midLat := (bbox.MinLat + bbox.MaxLat) / 2
-	lonStep := cellSizeKm / (kmPerDegreeLat * math.Cos(midLat*math.Pi/180))
+	lonStep := calculateLonStep(bbox, cellSizeKm)
 
 	var cells []Cell
 
@@ -104,13 +122,10 @@ func GenerateCells(bbox BoundingBox, cellSizeKm float64) []Cell {
 // EstimateCellCount returns how many cells GenerateCells would produce
 // without allocating them. Useful for logging or validation.
 func EstimateCellCount(bbox BoundingBox, cellSizeKm float64) int {
-	if cellSizeKm <= 0 {
-		cellSizeKm = 1.0
-	}
+	cellSizeKm = normalizeCellSizeKm(cellSizeKm)
 
 	latStep := cellSizeKm / kmPerDegreeLat
-	midLat := (bbox.MinLat + bbox.MaxLat) / 2
-	lonStep := cellSizeKm / (kmPerDegreeLat * math.Cos(midLat*math.Pi/180))
+	lonStep := calculateLonStep(bbox, cellSizeKm)
 
 	latCells := int(math.Ceil((bbox.MaxLat - bbox.MinLat) / latStep))
 	lonCells := int(math.Ceil((bbox.MaxLon - bbox.MinLon) / lonStep))
@@ -124,4 +139,27 @@ func EstimateCellCount(bbox BoundingBox, cellSizeKm float64) int {
 	}
 
 	return latCells * lonCells
+}
+
+func normalizeCellSizeKm(cellSizeKm float64) float64 {
+	if cellSizeKm <= 0 {
+		return 1.0
+	}
+
+	return cellSizeKm
+}
+
+func calculateLonStep(bbox BoundingBox, cellSizeKm float64) float64 {
+	midLat := (bbox.MinLat + bbox.MaxLat) / 2
+	cosMidLat := math.Cos(midLat * math.Pi / 180)
+
+	if math.Abs(cosMidLat) < minCosLatitude {
+		if cosMidLat < 0 {
+			cosMidLat = -minCosLatitude
+		} else {
+			cosMidLat = minCosLatitude
+		}
+	}
+
+	return cellSizeKm / (kmPerDegreeLat * cosMidLat)
 }

--- a/grid/grid.go
+++ b/grid/grid.go
@@ -1,0 +1,127 @@
+// Package grid provides utilities to divide a geographic bounding box into a
+// grid of smaller cells. This is useful for overcoming Google Maps' ~120
+// results-per-search limit: by splitting a large area into many small cells
+// and issuing one search per cell, you can retrieve far more results.
+package grid
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+const kmPerDegreeLat = 111.32
+
+// BoundingBox represents a geographic rectangle defined by two corners.
+type BoundingBox struct {
+	MinLat float64
+	MinLon float64
+	MaxLat float64
+	MaxLon float64
+}
+
+// ParseBoundingBox parses a string with format "minLat,minLon,maxLat,maxLon".
+// Example: "40.30,-3.80,40.50,-3.60"
+func ParseBoundingBox(s string) (BoundingBox, error) {
+	parts := strings.Split(s, ",")
+	if len(parts) != 4 {
+		return BoundingBox{}, fmt.Errorf("invalid bounding box %q: expected format minLat,minLon,maxLat,maxLon", s)
+	}
+
+	vals := make([]float64, 4)
+
+	for i, p := range parts {
+		v, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
+		if err != nil {
+			return BoundingBox{}, fmt.Errorf("invalid bounding box value %q: %w", p, err)
+		}
+
+		vals[i] = v
+	}
+
+	bbox := BoundingBox{
+		MinLat: vals[0],
+		MinLon: vals[1],
+		MaxLat: vals[2],
+		MaxLon: vals[3],
+	}
+
+	if bbox.MinLat >= bbox.MaxLat {
+		return BoundingBox{}, fmt.Errorf("minLat (%f) must be less than maxLat (%f)", bbox.MinLat, bbox.MaxLat)
+	}
+
+	if bbox.MinLon >= bbox.MaxLon {
+		return BoundingBox{}, fmt.Errorf("minLon (%f) must be less than maxLon (%f)", bbox.MinLon, bbox.MaxLon)
+	}
+
+	return bbox, nil
+}
+
+// Cell represents the center point of a grid cell.
+type Cell struct {
+	Lat float64
+	Lon float64
+}
+
+// GeoCoordinates returns the cell center in "lat,lon" format, ready to pass
+// to gmaps.NewGmapJob as the geoCoordinates parameter.
+func (c Cell) GeoCoordinates() string {
+	return fmt.Sprintf("%f,%f", c.Lat, c.Lon)
+}
+
+// GenerateCells divides bbox into a grid where each cell is approximately
+// cellSizeKm × cellSizeKm. It returns the center point of every cell.
+//
+// The longitude step is adjusted for the latitude of the bounding box centre
+// so that cells are roughly square on the ground.
+//
+// Example: a 20×20 km area with cellSizeKm=1 produces ~400 cells.
+func GenerateCells(bbox BoundingBox, cellSizeKm float64) []Cell {
+	if cellSizeKm <= 0 {
+		cellSizeKm = 1.0
+	}
+
+	// Latitude step is constant everywhere.
+	latStep := cellSizeKm / kmPerDegreeLat
+
+	// Longitude step varies with latitude; use the midpoint for a good estimate.
+	midLat := (bbox.MinLat + bbox.MaxLat) / 2
+	lonStep := cellSizeKm / (kmPerDegreeLat * math.Cos(midLat*math.Pi/180))
+
+	var cells []Cell
+
+	// Start at the centre of the first cell (half a step from the edge).
+	for lat := bbox.MinLat + latStep/2; lat < bbox.MaxLat; lat += latStep {
+		for lon := bbox.MinLon + lonStep/2; lon < bbox.MaxLon; lon += lonStep {
+			cells = append(cells, Cell{Lat: lat, Lon: lon})
+		}
+	}
+
+	return cells
+}
+
+// EstimateCellCount returns how many cells GenerateCells would produce
+// without allocating them. Useful for logging or validation.
+func EstimateCellCount(bbox BoundingBox, cellSizeKm float64) int {
+	if cellSizeKm <= 0 {
+		cellSizeKm = 1.0
+	}
+
+	latStep := cellSizeKm / kmPerDegreeLat
+	midLat := (bbox.MinLat + bbox.MaxLat) / 2
+	lonStep := cellSizeKm / (kmPerDegreeLat * math.Cos(midLat*math.Pi/180))
+
+	latCells := int(math.Ceil((bbox.MaxLat - bbox.MinLat) / latStep))
+	lonCells := int(math.Ceil((bbox.MaxLon - bbox.MinLon) / lonStep))
+
+	if latCells < 0 {
+		latCells = 0
+	}
+
+	if lonCells < 0 {
+		lonCells = 0
+	}
+
+	return latCells * lonCells
+}

--- a/grid/grid_test.go
+++ b/grid/grid_test.go
@@ -1,0 +1,89 @@
+package grid_test
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/gosom/google-maps-scraper/grid"
+)
+
+func TestParseBoundingBox(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		wantErr string
+	}{
+		{
+			name: "valid",
+			in:   "40.30,-3.80,40.50,-3.60",
+		},
+		{
+			name:    "invalid min latitude",
+			in:      "-91,0,10,10",
+			wantErr: "minLat",
+		},
+		{
+			name:    "invalid max longitude",
+			in:      "10,0,20,181",
+			wantErr: "maxLon",
+		},
+		{
+			name:    "non finite value",
+			in:      "NaN,0,10,10",
+			wantErr: "must be finite",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := grid.ParseBoundingBox(tc.in)
+			if tc.wantErr == "" && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateCellsAndEstimateCellCountNearPoles(t *testing.T) {
+	t.Parallel()
+
+	bbox := grid.BoundingBox{
+		MinLat: 89.90,
+		MinLon: 0.00,
+		MaxLat: 89.95,
+		MaxLon: 20.00,
+	}
+
+	cellSizeKm := 1.0
+
+	gotCells := grid.GenerateCells(bbox, cellSizeKm)
+	if len(gotCells) == 0 {
+		t.Fatal("expected cells to be generated near poles")
+	}
+
+	for _, c := range gotCells {
+		if math.IsNaN(c.Lat) || math.IsInf(c.Lat, 0) || math.IsNaN(c.Lon) || math.IsInf(c.Lon, 0) {
+			t.Fatalf("expected finite cell coordinates, got %+v", c)
+		}
+	}
+
+	gotCount := grid.EstimateCellCount(bbox, cellSizeKm)
+	if gotCount != len(gotCells) {
+		t.Fatalf("expected EstimateCellCount=%d to match generated cells=%d", gotCount, len(gotCells))
+	}
+}

--- a/runner/filerunner/filerunner.go
+++ b/runner/filerunner/filerunner.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gosom/google-maps-scraper/deduper"
 	"github.com/gosom/google-maps-scraper/exiter"
+	"github.com/gosom/google-maps-scraper/grid"
 	"github.com/gosom/google-maps-scraper/leadsdb"
 	"github.com/gosom/google-maps-scraper/runner"
 	"github.com/gosom/google-maps-scraper/tlmt"
@@ -76,19 +77,43 @@ func (r *fileRunner) Run(ctx context.Context) (err error) {
 	dedup := deduper.New()
 	exitMonitor := exiter.New()
 
-	seedJobs, err = runner.CreateSeedJobs(
-		r.cfg.FastMode,
-		r.cfg.LangCode,
-		r.input,
-		r.cfg.MaxDepth,
-		r.cfg.Email,
-		r.cfg.GeoCoordinates,
-		r.cfg.Zoom,
-		r.cfg.Radius,
-		dedup,
-		exitMonitor,
-		r.cfg.ExtraReviews,
-	)
+	if r.cfg.GridBBox != "" {
+		bbox, bboxErr := grid.ParseBoundingBox(r.cfg.GridBBox)
+		if bboxErr != nil {
+			return fmt.Errorf("invalid -grid-bbox: %w", bboxErr)
+		}
+
+		cellCount := grid.EstimateCellCount(bbox, r.cfg.GridCellKm)
+		fmt.Fprintf(os.Stderr, "grid scraping: ~%d cells (%.2f km each)\n", cellCount, r.cfg.GridCellKm)
+
+		seedJobs, err = runner.CreateGridSeedJobs(
+			r.cfg.LangCode,
+			r.input,
+			r.cfg.MaxDepth,
+			r.cfg.Email,
+			bbox,
+			r.cfg.GridCellKm,
+			r.cfg.Zoom,
+			dedup,
+			exitMonitor,
+			r.cfg.ExtraReviews,
+		)
+	} else {
+		seedJobs, err = runner.CreateSeedJobs(
+			r.cfg.FastMode,
+			r.cfg.LangCode,
+			r.input,
+			r.cfg.MaxDepth,
+			r.cfg.Email,
+			r.cfg.GeoCoordinates,
+			r.cfg.Zoom,
+			r.cfg.Radius,
+			dedup,
+			exitMonitor,
+			r.cfg.ExtraReviews,
+		)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/runner/filerunner/filerunner.go
+++ b/runner/filerunner/filerunner.go
@@ -78,6 +78,10 @@ func (r *fileRunner) Run(ctx context.Context) (err error) {
 	exitMonitor := exiter.New()
 
 	if r.cfg.GridBBox != "" {
+		if r.cfg.FastMode {
+			return fmt.Errorf("-fast-mode cannot be used together with -grid-bbox")
+		}
+
 		bbox, bboxErr := grid.ParseBoundingBox(r.cfg.GridBBox)
 		if bboxErr != nil {
 			return fmt.Errorf("invalid -grid-bbox: %w", bboxErr)

--- a/runner/jobs.go
+++ b/runner/jobs.go
@@ -73,17 +73,17 @@ func CreateSeedJobs(
 	scanner := bufio.NewScanner(r)
 
 	for scanner.Scan() {
-		query := strings.TrimSpace(scanner.Text())
-		if query == "" {
+		q, ok, parseErr := parseQueryLine(scanner.Text())
+		if parseErr != nil {
+			return nil, parseErr
+		}
+
+		if !ok {
 			continue
 		}
 
-		var id string
-
-		if before, after, ok := strings.Cut(query, "#!#"); ok {
-			query = strings.TrimSpace(before)
-			id = strings.TrimSpace(after)
-		}
+		query := q.text
+		id := q.id
 
 		var job scrapemate.IJob
 
@@ -150,6 +150,10 @@ func CreateGridSeedJobs(
 	exitMonitor exiter.Exiter,
 	extraReviews bool,
 ) ([]scrapemate.IJob, error) {
+	if zoom < 1 || zoom > 21 {
+		return nil, fmt.Errorf("invalid zoom level: %d", zoom)
+	}
+
 	cells := grid.GenerateCells(bbox, cellSizeKm)
 	if len(cells) == 0 {
 		return nil, fmt.Errorf("grid produced 0 cells — check bounding box and cell size")
@@ -223,24 +227,41 @@ func readQueries(r io.Reader) ([]query, error) {
 	scanner := bufio.NewScanner(r)
 
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
+		q, ok, parseErr := parseQueryLine(scanner.Text())
+		if parseErr != nil {
+			return nil, parseErr
 		}
 
-		q := query{}
-
-		if before, after, ok := strings.Cut(line, "#!#"); ok {
-			q.text = strings.TrimSpace(before)
-			q.id = strings.TrimSpace(after)
-		} else {
-			q.text = line
+		if !ok {
+			continue
 		}
 
 		queries = append(queries, q)
 	}
 
 	return queries, scanner.Err()
+}
+
+func parseQueryLine(line string) (query, bool, error) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return query{}, false, nil
+	}
+
+	var q query
+
+	if before, after, ok := strings.Cut(line, "#!#"); ok {
+		q.text = strings.TrimSpace(before)
+		q.id = strings.TrimSpace(after)
+	} else {
+		q.text = line
+	}
+
+	if q.text == "" {
+		return query{}, false, fmt.Errorf("invalid query line %q: empty query text", line)
+	}
+
+	return q, true, nil
 }
 
 func LoadCustomWriter(pluginDir, pluginName string) (scrapemate.ResultWriter, error) {

--- a/runner/jobs.go
+++ b/runner/jobs.go
@@ -10,9 +10,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/gosom/google-maps-scraper/deduper"
 	"github.com/gosom/google-maps-scraper/exiter"
 	"github.com/gosom/google-maps-scraper/gmaps"
+	"github.com/gosom/google-maps-scraper/grid"
 	"github.com/gosom/scrapemate"
 )
 
@@ -128,6 +130,117 @@ func CreateSeedJobs(
 	}
 
 	return jobs, scanner.Err()
+}
+
+// CreateGridSeedJobs reads search queries from r and produces one GmapJob per
+// (query, grid-cell) pair. Each cell covers approximately cellSizeKm × cellSizeKm
+// on the ground. The zoom level controls how much of the map Google Maps renders
+// per cell (use 14-16 for most cases).
+//
+// Deduplication across cells is handled automatically by the shared deduper.
+func CreateGridSeedJobs(
+	langCode string,
+	r io.Reader,
+	maxDepth int,
+	email bool,
+	bbox grid.BoundingBox,
+	cellSizeKm float64,
+	zoom int,
+	dedup deduper.Deduper,
+	exitMonitor exiter.Exiter,
+	extraReviews bool,
+) ([]scrapemate.IJob, error) {
+	cells := grid.GenerateCells(bbox, cellSizeKm)
+	if len(cells) == 0 {
+		return nil, fmt.Errorf("grid produced 0 cells — check bounding box and cell size")
+	}
+
+	queries, err := readQueries(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(queries) == 0 {
+		return nil, fmt.Errorf("no queries found in input")
+	}
+
+	var jobs []scrapemate.IJob
+
+	for _, q := range queries {
+		queryText := q.text
+		queryID := q.id
+
+		for _, cell := range cells {
+			// Each cell gets a unique ID derived from the query ID (or a new UUID).
+			cellID := uuid.New().String()
+			if queryID != "" {
+				cellID = fmt.Sprintf("%s-%s", queryID, cellID)
+			}
+
+			opts := []gmaps.GmapJobOptions{}
+
+			if dedup != nil {
+				opts = append(opts, gmaps.WithDeduper(dedup))
+			}
+
+			if exitMonitor != nil {
+				opts = append(opts, gmaps.WithExitMonitor(exitMonitor))
+			}
+
+			if extraReviews {
+				opts = append(opts, gmaps.WithExtraReviews())
+			}
+
+			job := gmaps.NewGmapJob(
+				cellID,
+				langCode,
+				queryText,
+				maxDepth,
+				email,
+				cell.GeoCoordinates(),
+				zoom,
+				opts...,
+			)
+
+			jobs = append(jobs, job)
+		}
+	}
+
+	return jobs, nil
+}
+
+// query holds a parsed input line.
+type query struct {
+	text string
+	id   string
+}
+
+// readQueries reads all non-empty lines from r and parses optional custom IDs
+// using the "#!#" delimiter (same format as CreateSeedJobs).
+func readQueries(r io.Reader) ([]query, error) {
+	var queries []query
+
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		q := query{}
+
+		if before, after, ok := strings.Cut(line, "#!#"); ok {
+			q.text = strings.TrimSpace(before)
+			q.id = strings.TrimSpace(after)
+		} else {
+			q.text = line
+		}
+
+		queries = append(queries, q)
+	}
+
+	return queries, scanner.Err()
 }
 
 func LoadCustomWriter(pluginDir, pluginName string) (scrapemate.ResultWriter, error) {

--- a/runner/jobs_test.go
+++ b/runner/jobs_test.go
@@ -1,0 +1,84 @@
+package runner_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gosom/google-maps-scraper/grid"
+	"github.com/gosom/google-maps-scraper/runner"
+)
+
+func TestCreateGridSeedJobsRejectsInvalidZoom(t *testing.T) {
+	t.Parallel()
+
+	bbox := grid.BoundingBox{
+		MinLat: 40.30,
+		MinLon: -3.80,
+		MaxLat: 40.50,
+		MaxLon: -3.60,
+	}
+
+	_, err := runner.CreateGridSeedJobs(
+		"en",
+		strings.NewReader("coffee"),
+		10,
+		false,
+		bbox,
+		1.0,
+		0,
+		nil,
+		nil,
+		false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "invalid zoom level") {
+		t.Fatalf("expected invalid zoom level error, got %v", err)
+	}
+}
+
+func TestCreateSeedJobsRejectsEmptyQueryBeforeCustomID(t *testing.T) {
+	t.Parallel()
+
+	_, err := runner.CreateSeedJobs(
+		false,
+		"en",
+		strings.NewReader("  #!#my-id\n"),
+		10,
+		false,
+		"",
+		15,
+		10000,
+		nil,
+		nil,
+		false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "empty query text") {
+		t.Fatalf("expected empty query text error, got %v", err)
+	}
+}
+
+func TestCreateGridSeedJobsRejectsEmptyQueryBeforeCustomID(t *testing.T) {
+	t.Parallel()
+
+	bbox := grid.BoundingBox{
+		MinLat: 40.30,
+		MinLon: -3.80,
+		MaxLat: 40.50,
+		MaxLon: -3.60,
+	}
+
+	_, err := runner.CreateGridSeedJobs(
+		"en",
+		strings.NewReader(" #!#my-id\n"),
+		10,
+		false,
+		bbox,
+		1.0,
+		15,
+		nil,
+		nil,
+		false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "empty query text") {
+		t.Fatalf("expected empty query text error, got %v", err)
+	}
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -80,6 +80,11 @@ type Config struct {
 	DisablePageReuse         bool
 	ExtraReviews             bool
 	LeadsDBAPIKey            string
+
+	// Grid scraping — divide a bounding box into cells to bypass the ~120
+	// results-per-search limit imposed by Google Maps.
+	GridBBox   string  // "minLat,minLon,maxLat,maxLon"
+	GridCellKm float64 // size of each grid cell in km (default: 1.0)
 }
 
 func ParseConfig() *Config {
@@ -127,6 +132,8 @@ func ParseConfig() *Config {
 	flag.BoolVar(&cfg.DisablePageReuse, "disable-page-reuse", false, "disable page reuse in playwright")
 	flag.BoolVar(&cfg.ExtraReviews, "extra-reviews", false, "enable extra reviews collection")
 	flag.StringVar(&cfg.LeadsDBAPIKey, "leadsdb-api-key", "", "LeadsDB API key for exporting results to LeadsDB")
+	flag.StringVar(&cfg.GridBBox, "grid-bbox", "", "bounding box for grid scraping: 'minLat,minLon,maxLat,maxLon' (e.g. '40.30,-3.80,40.50,-3.60')")
+	flag.Float64Var(&cfg.GridCellKm, "grid-cell", 1.0, "grid cell size in km [default: 1.0]. Use with -grid-bbox")
 
 	flag.Parse()
 


### PR DESCRIPTION
Introduces a new grid package and CLI flags that divide a geographic bounding box into a grid of smaller cells, issuing one search job per cell. This lets users scrape thousands of results from a large area by bypassing Google Maps' per-search cap.

New flags:
-grid-bbox "minLat,minLon,maxLat,maxLon" e.g. "40.30,-3.80,40.50,-3.60"
-grid-cell cell size in km (default 1.0)
-zoom reused to control the view per cell (default 15)

Results across overlapping cells are deduplicated automatically via the existing place-ID deduper.

