### PR TITLE
fix: extra reviews broken — nil map panic + missing JobData field

### DIFF
--- a/gmaps/reviews.go
+++ b/gmaps/reviews.go
@@ -198,6 +198,7 @@ const hexMatchPattern = `0x[0-9a-fA-F]+:0x[0-9a-fA-F]+` // Hex format place ID
 // extractPlaceID extracts the place ID from various Google Maps URL formats
 func extractPlaceID(mapURL string) (string, error) {
 	patternsOnce.Do(func() {
+		patterns = make(map[string]*regexp.Regexp)
 		// Try multiple patterns for extracting place ID
 		avail := []string{
 			`!1s([^!]+)`,                             // Standard format: !1s0x...

--- a/runner/webrunner/webrunner.go
+++ b/runner/webrunner/webrunner.go
@@ -194,7 +194,7 @@ func (w *webrunner) scrapeJob(ctx context.Context, job *web.Job) error {
 		}(),
 		dedup,
 		exitMonitor,
-		w.cfg.ExtraReviews,
+		w.cfg.ExtraReviews || job.Data.ExtraReviews,
 	)
 	if err != nil {
 		err2 := w.svc.Update(ctx, job)

--- a/web/job.go
+++ b/web/job.go
@@ -61,17 +61,18 @@ func (j *Job) Validate() error {
 }
 
 type JobData struct {
-	Keywords []string      `json:"keywords"`
-	Lang     string        `json:"lang"`
-	Zoom     int           `json:"zoom"`
-	Lat      string        `json:"lat"`
-	Lon      string        `json:"lon"`
-	FastMode bool          `json:"fast_mode"`
-	Radius   int           `json:"radius"`
-	Depth    int           `json:"depth"`
-	Email    bool          `json:"email"`
-	MaxTime  time.Duration `json:"max_time"`
-	Proxies  []string      `json:"proxies"`
+	Keywords     []string      `json:"keywords"`
+	Lang         string        `json:"lang"`
+	Zoom         int           `json:"zoom"`
+	Lat          string        `json:"lat"`
+	Lon          string        `json:"lon"`
+	FastMode     bool          `json:"fast_mode"`
+	Radius       int           `json:"radius"`
+	Depth        int           `json:"depth"`
+	Email        bool          `json:"email"`
+	ExtraReviews bool          `json:"extra_reviews"`
+	MaxTime      time.Duration `json:"max_time"`
+	Proxies      []string      `json:"proxies"`
 }
 
 func (d *JobData) Validate() error {


### PR DESCRIPTION
## Summary
Fixes #242 — Extra reviews not working.

Two bugs prevented `-extra-reviews` from working via the web API:

### Bug 1: Nil map panic in `extractPlaceID` (reviews.go)
The `patterns` map was declared but never initialized with `make()`. This caused a panic on first use, crashing the RPC-based review extraction path entirely.

**Fix:** Added `patterns = make(map[string]*regexp.Regexp)` in the `patternsOnce.Do` block.

### Bug 2: Missing `ExtraReviews` field in web `JobData` struct (web/job.go)
The `JobData` struct didn't have an `ExtraReviews` field. When `extra_reviews: true` was sent via the `/api/v1/jobs` POST endpoint, Go's JSON unmarshaler silently dropped it. Jobs were stored without the flag, so `PlaceJob.ExtractExtraReviews` was always false.

**Fix:** Added `ExtraReviews bool \`json:"extra_reviews"\`` to `JobData`, and updated the webrunner to use `job.Data.ExtraReviews || w.cfg.ExtraReviews` so both per-job API param and global CLI flag work.

### Verified
- Before fix: 8 reviews returned for a business with 167 Google reviews
- After fix: all 167 reviews returned in `user_reviews_extended`
- Tested on self-hosted Railway deployment with residential proxy