### PR TITLE
fix(reviews): return direct photo URL instead of imagery/report link (#240)

### DIFF
--- a/gmaps/entry.go
+++ b/gmaps/entry.go
@@ -525,16 +525,15 @@ func parseReviews(reviewsI []any) []Review {
 			continue
 		}
 
-		// Try multiple paths for images
-		optsI := getNthElementAndCast[[]any](el, 2, 2, 0, 1, 21, 7)
-		if len(optsI) == 0 {
-			optsI = getNthElementAndCast[[]any](el, 2, 2, 0, 1, 7)
-		}
-
-		for j := range optsI {
-			val := getNthElementAndCast[string](optsI, j)
-			if val != "" && len(val) > 2 {
-				review.Images = append(review.Images, val[2:])
+		// Extract user-contributed photo URLs for this review.
+		// Structure: el[2][2] is the image list; each image's direct lh3 URL lives at [1][6][0].
+		// The previous paths (e.g. [2][2][0][1][21][7]) landed on the imagery/report
+		// "report this photo" URL, not the actual hosted image. See issue #240.
+		imgs := getNthElementAndCast[[]any](el, 2, 2)
+		for j := range imgs {
+			url := getNthElementAndCast[string](imgs, j, 1, 6, 0)
+			if url != "" {
+				review.Images = append(review.Images, url)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Fixes #240 — `user_reviews[].Images` was returning Google's "report this photo" moderation URL instead of the hosted image URL, making the field unusable for rendering.

### The bug

`parseReviews` in `gmaps/entry.go` navigated the review element at `el[2][2][0][1][21][7]` (with a fallback at `el[2][2][0][1][7]`). Both paths land on the `imagery/report` endpoint, so the output looked like:

```
www.google.com/local/imagery/report/?cb_client=maps_sv.tactile&image_key=!1e10!2sCIHM...&fid=0x0:0x...
```

### The fix

The real image list lives at `el[2][2]`. Within each image entry, the direct `lh3.googleusercontent.com/geougc-cs/...` URL is at `[1][6][0]`. Walking that path gives properly renderable URLs:

```
https://lh3.googleusercontent.com/geougc-cs/AMG9lEQS2OZxWHqdLso3RPF0...=w1200-h900-p
```

Verified against a live scrape (Sweet Thrills, Toronto) — 10 reviews-with-images now return working image URLs that match what the Google Maps UI serves.

## Test plan
- [x] Rebuilt image locally and ran against a place with image-bearing reviews
- [x] Confirmed `Images` array now contains `lh3.googleusercontent.com` URLs that load in a browser
- [x] Confirmed review count and all other review fields unchanged