### PR TITLE
gmaps,postgres: fix typo in field name and use idiomatic time.Since

### DIFF
--- a/gmaps/place.go
+++ b/gmaps/place.go
@@ -17,7 +17,7 @@ type PlaceJobOptions func(*PlaceJob)
 type PlaceJob struct {
 	scrapemate.Job
 
-	UsageInResultststs      bool
+	UsageInResults          bool
 	ExtractEmail            bool
 	ExitMonitor             exiter.Exiter
 	ExtractExtraReviews     bool
@@ -42,7 +42,7 @@ func NewPlaceJob(parentID, langCode, u string, extractEmail, extraExtraReviews b
 		},
 	}
 
-	job.UsageInResultststs = true
+	job.UsageInResults = true
 	job.ExtractEmail = extractEmail
 	job.ExtractExtraReviews = extraExtraReviews
 
@@ -133,7 +133,7 @@ func (j *PlaceJob) Process(_ context.Context, resp *scrapemate.Response) (any, [
 
 		emailJob := NewEmailJob(j.ID, &entry, opts...)
 
-		j.UsageInResultststs = false
+		j.UsageInResults = false
 
 		return nil, []scrapemate.IJob{emailJob}, nil
 	} else if j.ExitMonitor != nil && !j.WriterManagedCompletion {
@@ -291,7 +291,7 @@ func (j *PlaceJob) getReviewCount(data []byte) int {
 }
 
 func (j *PlaceJob) UseInResults() bool {
-	return j.UsageInResultststs
+	return j.UsageInResults
 }
 
 const js = `

--- a/postgres/resultwriter.go
+++ b/postgres/resultwriter.go
@@ -40,7 +40,7 @@ func (r *resultWriter) Run(ctx context.Context, in <-chan scrapemate.Result) err
 
 		buff = append(buff, entry)
 
-		if len(buff) >= maxBatchSize || time.Now().UTC().Sub(lastSave) >= time.Minute {
+		if len(buff) >= maxBatchSize || time.Since(lastSave) >= time.Minute {
 			err := r.batchSave(ctx, buff)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Changes

### Fix typo in PlaceJob field name
`UsageInResultststs` → `UsageInResults` — the extra "tsts" is an obvious keyboard fumble. The public method was already correctly named `UseInResults()`; this fixes the backing field to match.

### Use idiomatic `time.Since` in resultWriter
Replace `time.Now().UTC().Sub(lastSave)` with `time.Since(lastSave)` — the standard library helper that does the same thing more concisely.

## Verification
- `gofmt` clean
- `go test ./gmaps/...` passes