### PR TITLE
gmaps: emit both 'longitude' and 'longtitude' JSON keys

### DIFF
--- a/gmaps/entry.go
+++ b/gmaps/entry.go
@@ -76,6 +76,10 @@ type Entry struct {
 	ReviewRating        float64                `json:"review_rating"`
 	ReviewsPerRating    map[int]int            `json:"reviews_per_rating"`
 	Latitude            float64                `json:"latitude"`
+	// Longtitude holds the longitude. The struct field and the legacy JSON
+	// key are misspelled ("longtitude"); MarshalJSON also emits the correctly
+	// spelled "longitude" key, and UnmarshalJSON accepts either. The field
+	// name is kept for backwards compatibility with existing imports.
 	Longtitude          float64                `json:"longtitude"`
 	Status              string                 `json:"status"`
 	Description         string                 `json:"description"`
@@ -95,6 +99,42 @@ type Entry struct {
 	UserReviews         []Review               `json:"user_reviews"`
 	UserReviewsExtended []Review               `json:"user_reviews_extended"`
 	Emails              []string               `json:"emails"`
+}
+
+// entryAlias is used inside Marshal/UnmarshalJSON to avoid infinite recursion
+// while still benefiting from the struct's json tags for every other field.
+type entryAlias Entry
+
+// MarshalJSON emits both the legacy "longtitude" key (preserved for backwards
+// compatibility) and the correctly spelled "longitude" key so downstream
+// consumers can migrate without a flag day.
+func (e Entry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Longitude float64 `json:"longitude"`
+		entryAlias
+	}{
+		Longitude:  e.Longtitude,
+		entryAlias: entryAlias(e),
+	})
+}
+
+// UnmarshalJSON accepts either "longtitude" (legacy) or "longitude" (preferred)
+// as the longitude key. "longtitude" wins when both are present so existing
+// data files keep round-tripping byte-identical.
+func (e *Entry) UnmarshalJSON(data []byte) error {
+	aux := struct {
+		Longitude *float64 `json:"longitude"`
+		*entryAlias
+	}{
+		entryAlias: (*entryAlias)(e),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if e.Longtitude == 0 && aux.Longitude != nil {
+		e.Longtitude = *aux.Longitude
+	}
+	return nil
 }
 
 func (e *Entry) haversineDistance(lat, lon float64) float64 {

--- a/gmaps/entry_test.go
+++ b/gmaps/entry_test.go
@@ -1,6 +1,7 @@
 package gmaps_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -201,6 +202,35 @@ func Test_EntryFromJSONRaw2(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Greater(t, len(entry.About), 0)
+}
+
+func Test_EntryMarshalEmitsBothLongitudeKeys(t *testing.T) {
+	entry := gmaps.Entry{Title: "x", Category: "y", Latitude: 1.5, Longtitude: 2.5}
+
+	raw, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	var got map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &got))
+
+	require.JSONEq(t, "2.5", string(got["longtitude"]), "legacy key preserved")
+	require.JSONEq(t, "2.5", string(got["longitude"]), "correctly spelled alias emitted")
+}
+
+func Test_EntryUnmarshalAcceptsEitherLongitudeKey(t *testing.T) {
+	var legacy gmaps.Entry
+	require.NoError(t, json.Unmarshal([]byte(`{"longtitude":42.5}`), &legacy))
+	require.Equal(t, 42.5, legacy.Longtitude)
+
+	var modern gmaps.Entry
+	require.NoError(t, json.Unmarshal([]byte(`{"longitude":42.5}`), &modern))
+	require.Equal(t, 42.5, modern.Longtitude)
+
+	// When both are present, the legacy spelling wins so existing files
+	// round-trip byte-identical.
+	var both gmaps.Entry
+	require.NoError(t, json.Unmarshal([]byte(`{"longtitude":1.0,"longitude":2.0}`), &both))
+	require.Equal(t, 1.0, both.Longtitude)
 }
 
 func Test_EntryFromJsonC(t *testing.T) {


### PR DESCRIPTION
## Problem

The `Entry.Longtitude` field has shipped with the misspelled JSON key `"longtitude"` since the project started. The CSV exporter already uses the correct spelling (`CsvHeaders[14] = "longitude"` in `gmaps/entry.go`), but the JSON output and the Go struct field still use the typo.

Downstream consumers reading the JSON output either copy the typo into their schemas or have to work around it. I ran into this while wiring gosom into [trinkhallen-data](https://github.com/boredland/trinkhallen-data) — naively reading `longitude` from the result silently dropped every record because the actual key is `longtitude`.

## Fix

Renaming the JSON tag outright would break every existing parser, so this PR keeps the legacy key and adds the correctly spelled one as an alias:

- `MarshalJSON` emits **both** `"longtitude"` (preserved verbatim) and `"longitude"` so new consumers can read the correct key and old consumers keep working.
- `UnmarshalJSON` accepts either key; `"longtitude"` wins when both are present so existing data files round-trip byte-identical.

The Go struct field is intentionally left as `Longtitude` — renaming it would break every importer of the package. The field's doc comment now points new code at the correct JSON key.

## Tests

Two new tests in `gmaps/entry_test.go`:

- `Test_EntryMarshalEmitsBothLongitudeKeys` — verifies the output contains both keys with the same value.
- `Test_EntryUnmarshalAcceptsEitherLongitudeKey` — verifies legacy, modern, and both-present inputs all populate `Longtitude` correctly.

Full test suite (`go test ./gmaps/`) and `go vet ./gmaps/` both pass. Existing `Test_EntryFromJSON*` tests untouched.

## Compatibility

- JSON output: **additive only.** Every existing key keeps its name and value. New `"longitude"` key appears alongside.
- JSON input: **strictly more permissive.** Was: only `"longtitude"` parsed. Now: either key parses.
- Go API: unchanged. `Entry.Longtitude` remains exported with the same type.