### PR TITLE
fix: review date extraction

### DIFF
--- a/gmaps/entry.go
+++ b/gmaps/entry.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type Image struct {
@@ -56,7 +57,12 @@ type Review struct {
 	Description    string
 	Images         []string
 	When           string
+	PublishedAt    *time.Time `json:"published_at,omitempty"`
 }
+
+const reviewPublishedAtFutureSkew = 24 * time.Hour
+
+var earliestReviewPublishedAt = time.Date(2007, time.January, 1, 0, 0, 0, 0, time.UTC)
 
 type Entry struct {
 	ID         string              `json:"input_id"`
@@ -467,65 +473,13 @@ func parseReviews(reviewsI []any) []Review {
 			}
 		}
 
-		// Try multiple paths for date (relative time)
-		// Path 1: el[1][6] = "7 months ago"
-		// Path 2: el[2][1][3][8][0] = "4 years ago"
-var relativeDate string
-		date16 := getNthElementAndCast[string](el, 1, 6)
-		date33 := getNthElementAndCast[string](el, 3, 3)
-		date213080 := getNthElementAndCast[string](el, 2, 1, 3, 8, 0)
-
-		// Try multiple paths for date (relative time)
-		if date16 != "" {
-			relativeDate = date16
-		} else if date33 != "" {
-			relativeDate = date33
-		} else if date213080 != "" {
-			relativeDate = date213080
-		}
-
-		// Try multiple paths for profile picture
-		profilePic, err := decodeURL(getNthElementAndCast[string](el, 1, 4, 5, 1))
-		if err != nil || profilePic == "" {
-			profilePic = getNthElementAndCast[string](el, 1, 2, 0)
-			if profilePic == "" {
-				profilePic = getNthElementAndCast[string](el, 0, 2, 0)
-			}
-		}
-
-		// Try multiple paths for author name
-		authorName := getNthElementAndCast[string](el, 1, 4, 5, 0)
-		if authorName == "" {
-			authorName = getNthElementAndCast[string](el, 1, 4, 4)
-			if authorName == "" {
-				authorName = getNthElementAndCast[string](el, 0, 1)
-			}
-		}
-
-		// Try multiple paths for rating
-		rating := int(getNthElementAndCast[float64](el, 2, 0, 0))
-		if rating == 0 {
-			rating = int(getNthElementAndCast[float64](el, 2, 0))
-			if rating == 0 {
-				rating = int(getNthElementAndCast[float64](el, 1, 0, 0))
-			}
-		}
-
-		// Try multiple paths for description
-		description := getNthElementAndCast[string](el, 2, 15, 0, 0)
-		if description == "" {
-			description = getNthElementAndCast[string](el, 2, 15, 0)
-			if description == "" {
-				description = getNthElementAndCast[string](el, 3, 0)
-			}
-		}
-
 		review := Review{
-			Name:           authorName,
-			ProfilePicture: profilePic,
-			When:           relativeDate,
-			Rating:         rating,
-			Description:    description,
+			Name:           reviewAuthorName(el),
+			ProfilePicture: reviewProfilePicture(el),
+			When:           reviewRelativeDate(el),
+			PublishedAt:    reviewPublishedAt(el),
+			Rating:         reviewRating(el),
+			Description:    reviewDescription(el),
 		}
 
 		if review.Name == "" {
@@ -548,6 +502,91 @@ var relativeDate string
 	}
 
 	return ans
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func reviewRelativeDate(el []any) string {
+	return firstNonEmpty(
+		getNthElementAndCast[string](el, 1, 6),
+		getNthElementAndCast[string](el, 3, 3),
+		getNthElementAndCast[string](el, 2, 1, 3, 8, 0),
+	)
+}
+
+func reviewPublishedAt(el []any) *time.Time {
+	timestampMicros := firstNonZero(
+		getNthElementAndCast[float64](el, 1, 2),
+		getNthElementAndCast[float64](el, 1, 3),
+	)
+	if timestampMicros == 0 {
+		return nil
+	}
+
+	publishedAt := time.UnixMicro(int64(timestampMicros)).UTC()
+	if publishedAt.Before(earliestReviewPublishedAt) {
+		return nil
+	}
+
+	if publishedAt.After(time.Now().UTC().Add(reviewPublishedAtFutureSkew)) {
+		return nil
+	}
+
+	return &publishedAt
+}
+
+func reviewProfilePicture(el []any) string {
+	profilePic, err := decodeURL(getNthElementAndCast[string](el, 1, 4, 5, 1))
+	if err == nil && profilePic != "" {
+		return profilePic
+	}
+
+	return firstNonEmpty(
+		getNthElementAndCast[string](el, 1, 2, 0),
+		getNthElementAndCast[string](el, 0, 2, 0),
+	)
+}
+
+func reviewAuthorName(el []any) string {
+	return firstNonEmpty(
+		getNthElementAndCast[string](el, 1, 4, 5, 0),
+		getNthElementAndCast[string](el, 1, 4, 4),
+		getNthElementAndCast[string](el, 0, 1),
+	)
+}
+
+func reviewRating(el []any) int {
+	return int(firstNonZero(
+		getNthElementAndCast[float64](el, 2, 0, 0),
+		getNthElementAndCast[float64](el, 2, 0),
+		getNthElementAndCast[float64](el, 1, 0, 0),
+	))
+}
+
+func firstNonZero(values ...float64) float64 {
+	for _, value := range values {
+		if value != 0 {
+			return value
+		}
+	}
+
+	return 0
+}
+
+func reviewDescription(el []any) string {
+	return firstNonEmpty(
+		getNthElementAndCast[string](el, 2, 15, 0, 0),
+		getNthElementAndCast[string](el, 2, 15, 0),
+		getNthElementAndCast[string](el, 3, 0),
+	)
 }
 
 type getLinkSourceParams struct {

--- a/gmaps/entry.go
+++ b/gmaps/entry.go
@@ -470,12 +470,16 @@ func parseReviews(reviewsI []any) []Review {
 		// Try multiple paths for date (relative time)
 		// Path 1: el[1][6] = "7 months ago"
 		// Path 2: el[2][1][3][8][0] = "4 years ago"
-		var relativeDate string
+var relativeDate string
 		date16 := getNthElementAndCast[string](el, 1, 6)
+		date33 := getNthElementAndCast[string](el, 3, 3)
 		date213080 := getNthElementAndCast[string](el, 2, 1, 3, 8, 0)
 
+		// Try multiple paths for date (relative time)
 		if date16 != "" {
 			relativeDate = date16
+		} else if date33 != "" {
+			relativeDate = date33
 		} else if date213080 != "" {
 			relativeDate = date213080
 		}

--- a/gmaps/entry.go
+++ b/gmaps/entry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"log"
 	"math"
 	"net/url"
 	"runtime/debug"
@@ -258,11 +259,12 @@ func extractReviews(data []byte) []Review {
 
 	var jd []any
 	if err := json.Unmarshal(data, &jd); err != nil {
-		fmt.Printf("Error unmarshalling RPC JSON: %v (data len: %d)\n", err, len(data))
+		log.Printf("DEBUG: Error unmarshalling RPC JSON: %v (data len: %d)", err, len(data))
 		return nil
 	}
 
 	if len(jd) < 3 {
+		log.Printf("DEBUG: RPC response has only %d elements, expected 3+", len(jd))
 		return nil
 	}
 
@@ -465,10 +467,17 @@ func parseReviews(reviewsI []any) []Review {
 			}
 		}
 
-		// Try multiple paths for the timestamp
-		time := getNthElementAndCast[[]any](el, 2, 2, 0, 1, 21, 6, 8)
-		if len(time) == 0 {
-			time = getNthElementAndCast[[]any](el, 2, 2, 0, 1, 6, 8)
+		// Try multiple paths for date (relative time)
+		// Path 1: el[1][6] = "7 months ago"
+		// Path 2: el[2][1][3][8][0] = "4 years ago"
+		var relativeDate string
+		date16 := getNthElementAndCast[string](el, 1, 6)
+		date213080 := getNthElementAndCast[string](el, 2, 1, 3, 8, 0)
+
+		if date16 != "" {
+			relativeDate = date16
+		} else if date213080 != "" {
+			relativeDate = date213080
 		}
 
 		// Try multiple paths for profile picture
@@ -510,15 +519,9 @@ func parseReviews(reviewsI []any) []Review {
 		review := Review{
 			Name:           authorName,
 			ProfilePicture: profilePic,
-			When: func() string {
-				if len(time) < 3 {
-					return ""
-				}
-
-				return fmt.Sprintf("%v-%v-%v", time[0], time[1], time[2])
-			}(),
-			Rating:      rating,
-			Description: description,
+			When:           relativeDate,
+			Rating:         rating,
+			Description:    description,
 		}
 
 		if review.Name == "" {

--- a/gmaps/entry_internal_test.go
+++ b/gmaps/entry_internal_test.go
@@ -1,0 +1,172 @@
+package gmaps
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseReviewsRelativeDatePaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		wrapped bool
+		path    []int
+		when    string
+	}{
+		{
+			name:    "inline review metadata path",
+			wrapped: true,
+			path:    []int{1, 6},
+			when:    "7 months ago",
+		},
+		{
+			name: "direct review fallback path",
+			path: []int{3, 3},
+			when: "3 weeks ago",
+		},
+		{
+			name: "nested review rpc path",
+			path: []int{2, 1, 3, 8, 0},
+			when: "4 years ago",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			review := newReviewElement()
+			setNested(review, tt.when, tt.path...)
+
+			item := any(review)
+			if tt.wrapped {
+				item = []any{review}
+			}
+
+			reviews := parseReviews([]any{item})
+
+			require.Len(t, reviews, 1)
+			require.Equal(t, tt.when, reviews[0].When)
+			require.Equal(t, "Ada Lovelace", reviews[0].Name)
+			require.Equal(t, 5, reviews[0].Rating)
+			require.Equal(t, "Clear review text", reviews[0].Description)
+		})
+	}
+}
+
+func TestParseReviewsPublishedAtFromMicrosecondTimestamp(t *testing.T) {
+	review := newReviewElement()
+	setNested(review, "6 months ago", 1, 6)
+	setNested(review, 1764184138462529.0, 1, 2)
+
+	reviews := parseReviews([]any{review})
+
+	require.Len(t, reviews, 1)
+	require.NotNil(t, reviews[0].PublishedAt)
+	require.Equal(t, "2025-11-26T19:08:58.462529Z", reviews[0].PublishedAt.Format(time.RFC3339Nano))
+}
+
+func TestParseReviewsPublishedAtFallsBackToSecondTimestampPath(t *testing.T) {
+	review := newReviewElement()
+	setNested(review, "6 months ago", 1, 6)
+	setNested(review, 1764184138462529.0, 1, 3)
+
+	reviews := parseReviews([]any{review})
+
+	require.Len(t, reviews, 1)
+	require.NotNil(t, reviews[0].PublishedAt)
+	require.Equal(t, "2025-11-26T19:08:58.462529Z", reviews[0].PublishedAt.Format(time.RFC3339Nano))
+}
+
+func TestParseReviewsPublishedAtRejectsInvalidTimestamps(t *testing.T) {
+	tests := []struct {
+		name   string
+		micros float64
+	}{
+		{
+			name: "missing",
+		},
+		{
+			name:   "before lower bound",
+			micros: float64(time.Date(2006, time.December, 31, 23, 59, 59, 0, time.UTC).UnixMicro()),
+		},
+		{
+			name:   "too far in future",
+			micros: float64(time.Now().UTC().Add(48 * time.Hour).UnixMicro()),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			review := newReviewElement()
+			setNested(review, "6 months ago", 1, 6)
+
+			if tt.micros != 0 {
+				setNested(review, tt.micros, 1, 2)
+			}
+
+			reviews := parseReviews([]any{review})
+
+			require.Len(t, reviews, 1)
+			require.Nil(t, reviews[0].PublishedAt)
+		})
+	}
+}
+
+func TestParseReviewsSkipsItemsWithoutAuthor(t *testing.T) {
+	review := make([]any, 4)
+	setNested(review, "yesterday", 1, 6)
+	setNested(review, 5.0, 2, 0, 0)
+
+	reviews := parseReviews([]any{review})
+
+	require.Empty(t, reviews)
+}
+
+func newReviewElement() []any {
+	review := make([]any, 4)
+
+	setNested(review, "Ada Lovelace", 1, 4, 5, 0)
+	setNested(review, 5.0, 2, 0, 0)
+	setNested(review, "Clear review text", 2, 15, 0, 0)
+
+	return review
+}
+
+func setNested(root []any, value any, path ...int) {
+	setNestedValue(root, value, path...)
+}
+
+func setNestedValue(current []any, value any, path ...int) []any {
+	if len(path) == 0 {
+		return current
+	}
+
+	index := path[0]
+	current = ensureLen(current, index+1)
+
+	if len(path) == 1 {
+		current[index] = value
+
+		return current
+	}
+
+	next, ok := current[index].([]any)
+	if !ok {
+		next = make([]any, path[1]+1)
+	}
+
+	current[index] = setNestedValue(next, value, path[1:]...)
+
+	return current
+}
+
+func ensureLen(items []any, length int) []any {
+	if len(items) >= length {
+		return items
+	}
+
+	extended := make([]any, length)
+	copy(extended, items)
+
+	return extended
+}


### PR DESCRIPTION
 ## Summary

  - Refactors review parsing so positional Google Maps review fields are extracted through focused helper functions.
  - Adds published_at to parsed reviews using Google’s microsecond timestamp fields.
  - Keeps existing relative When behavior intact while adding a more precise timestamp when available.
  - Adds focused tests for known review date shapes, timestamp parsing, fallback behavior, invalid timestamps, and skipped authorless reviews.

  ## Details

  Google Maps review payloads expose relative review dates like "4 months ago", but the RPC review data also includes epoch-like microsecond timestamps. This change extracts those timestamps from the known review metadata paths:

  - primary: el[1][2]
  - fallback: el[1][3]

  The timestamp is converted to UTC and emitted as published_at.

  To avoid accepting unrelated numeric fields if Google changes the payload shape, the parser only accepts plausible review timestamps:

  - not before 2007-01-01T00:00:00Z
  - not after now + 24h

  ## Validation

  - go test ./gmaps
  - make test
  - make lint

  Live validation was also run , confirming reviews still extract correctly and include published_at.
