### PR TITLE
docs: add Managed Cloud Alternatives section

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,14 @@ See [AGENTS.md](AGENTS.md) for development guidelines.
 
 ---
 
+## Managed Cloud Alternatives
+
+Prefer not to self-host? These services provide Google Maps data extraction without infrastructure setup:
+
+- [gmapsscraper.io](https://gmapsscraper.io) — Managed API for Google Maps leads; export to CSV/JSON, credit-based pricing, no server required
+
+---
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## What this adds

A new **Managed Cloud Alternatives** section after the References section, for users who prefer not to self-host.

Many users of this project are non-technical — they want Google Maps lead data but don't want to manage Docker, servers, or proxies. Having a pointer to managed alternatives helps them while keeping the project's focus on the self-hosted open-source tool.

## Added entry

- [gmapsscraper.io](https://gmapsscraper.io) — Managed API for Google Maps leads; export to CSV/JSON, credit-based pricing, no server required

Happy to adjust the wording or placement if you prefer a different format. Thanks for maintaining such a great project!