### PR TITLE
Fix payment option ambiguity in Maps output

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ go build
 ## Extracted Data Points
 
 <details>
-<summary><strong>Click to expand all 33 data points</strong></summary>
+<summary><strong>Click to expand all 36 data points</strong></summary>
 
 | # | Field | Description |
 |---|-------|-------------|
@@ -382,17 +382,19 @@ go build
 | 21 | `timezone` | Business timezone |
 | 22 | `price_range` | Price level ($, $$, $$$) |
 | 23 | `data_id` | Internal Google Maps identifier |
-| 24 | `images` | Associated image URLs |
-| 25 | `reservations` | Reservation booking link |
-| 26 | `order_online` | Online ordering link |
-| 27 | `menu` | Menu link |
-| 28 | `owner` | Owner-claimed status |
-| 29 | `complete_address` | Full formatted address |
-| 30 | `about` | Additional business info |
-| 31 | `user_reviews` | Customer reviews (text, rating, timestamp) |
-| 32 | `emails` | Extracted email addresses (requires `-email` flag) |
-| 33 | `user_reviews_extended` | Extended reviews up to ~300 (requires `-extra-reviews`) |
-| 34 | `place_id` | Google's unique place id |
+| 24 | `street_view_url` | Street View URL |
+| 25 | `place_id` | Google's unique place id |
+| 26 | `images` | Associated image URLs |
+| 27 | `reservations` | Reservation booking link |
+| 28 | `order_online` | Online ordering link |
+| 29 | `menu` | Menu link |
+| 30 | `owner` | Owner-claimed status |
+| 31 | `complete_address` | Full formatted address |
+| 32 | `credit_cards_accepted` | Accepted credit card networks |
+| 33 | `about` | Additional business info |
+| 34 | `user_reviews` | Customer reviews (text, rating, timestamp) |
+| 35 | `user_reviews_extended` | Extended reviews up to ~300 (requires `-extra-reviews`) |
+| 36 | `emails` | Extracted email addresses (requires `-email` flag) |
 
 </details>
 

--- a/gmaps/entry.go
+++ b/gmaps/entry.go
@@ -43,8 +43,9 @@ type Address struct {
 }
 
 type Option struct {
-	Name    string `json:"name"`
-	Enabled bool   `json:"enabled"`
+	Name    string   `json:"name"`
+	Enabled bool     `json:"enabled"`
+	Values  []string `json:"values,omitempty"`
 }
 
 type About struct {
@@ -125,6 +126,7 @@ type Entry struct {
 	Menu                LinkSource   `json:"menu"`
 	Owner               Owner        `json:"owner"`
 	CompleteAddress     Address      `json:"complete_address"`
+	CreditCardsAccepted []string     `json:"credit_cards_accepted"`
 	About               []About      `json:"about"`
 	UserReviews         []Review     `json:"user_reviews"`
 	UserReviewsExtended []Review     `json:"user_reviews_extended"`
@@ -263,6 +265,7 @@ func (e *Entry) CsvHeaders() []string {
 		"menu",
 		"owner",
 		"complete_address",
+		"credit_cards_accepted",
 		"about",
 		"user_reviews",
 		"user_reviews_extended",
@@ -303,6 +306,7 @@ func (e *Entry) CsvRow() []string {
 		stringify(e.Menu),
 		stringify(e.Owner),
 		stringify(e.CompleteAddress),
+		stringSliceToString(e.CreditCardsAccepted),
 		stringify(e.About),
 		stringify(e.UserReviews),
 		stringify(e.UserReviewsExtended),
@@ -497,10 +501,15 @@ func EntryFromJSON(raw []byte, reviewCountOnly ...bool) (entry Entry, err error)
 			opt := Option{
 				Enabled: (getNthElementAndCast[float64](optsI, j, 2, 1, 0, 0)) == 1,
 				Name:    getNthElementAndCast[string](optsI, j, 1),
+				Values:  getOptionValues(getNthElementAndCast[[]any](optsI, j)),
 			}
 
 			if opt.Name != "" {
-				about.Options = append(about.Options, opt)
+				addOrMergeOption(&about.Options, opt)
+			}
+
+			if about.ID == "payments" && opt.Name == "Credit cards" && len(opt.Values) > 0 {
+				entry.CreditCardsAccepted = mergeStringSlices(entry.CreditCardsAccepted, opt.Values)
 			}
 		}
 
@@ -894,6 +903,49 @@ func getNthElementAndCast[T any](arr []any, indexes ...int) T {
 
 func stringSliceToString(s []string) string {
 	return strings.Join(s, ", ")
+}
+
+func addOrMergeOption(options *[]Option, opt Option) {
+	for i := range *options {
+		if (*options)[i].Name != opt.Name {
+			continue
+		}
+
+		(*options)[i].Enabled = (*options)[i].Enabled || opt.Enabled
+		(*options)[i].Values = mergeStringSlices((*options)[i].Values, opt.Values)
+
+		return
+	}
+
+	*options = append(*options, opt)
+}
+
+func getOptionValues(opt []any) []string {
+	valuesI := getNthElementAndCast[[]any](opt, 2, 4, 1, 0, 0)
+	values := make([]string, 0, len(valuesI))
+
+	for i := range valuesI {
+		value := getNthElementAndCast[string](valuesI, i, 2)
+		if value == "" {
+			value = getNthElementAndCast[string](valuesI, i, 3)
+		}
+
+		if value != "" {
+			values = append(values, value)
+		}
+	}
+
+	return values
+}
+
+func mergeStringSlices(current, next []string) []string {
+	for _, value := range next {
+		if !slices.Contains(current, value) {
+			current = append(current, value)
+		}
+	}
+
+	return current
 }
 
 func stringify(v any) string {

--- a/gmaps/entry_test.go
+++ b/gmaps/entry_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/PuerkitoBio/goquery"
@@ -122,6 +123,7 @@ func Test_EntryFromJSON(t *testing.T) {
 			State:      "",
 			Country:    "CY",
 		},
+		CreditCardsAccepted: []string{"Mastercard"},
 		ReviewsPerRating: map[int]int{
 			1: 37,
 			2: 16,
@@ -202,6 +204,65 @@ func Test_EntryFromJSONRaw2(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Greater(t, len(entry.About), 0)
+}
+
+func Test_EntryFromJSONExtractsAcceptedCreditCards(t *testing.T) {
+	raw, err := os.ReadFile("../testdata/panic2.json")
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	entry, err := gmaps.EntryFromJSON(raw)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"American Express", "Diners Club", "Mastercard", "VISA"}, entry.CreditCardsAccepted)
+}
+
+func Test_EntryFromJSONMergesDuplicateAboutOptions(t *testing.T) {
+	raw, err := os.ReadFile("../testdata/panic2.json")
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	entry, err := gmaps.EntryFromJSON(raw)
+	require.NoError(t, err)
+
+	var payments gmaps.About
+
+	for _, about := range entry.About {
+		if about.ID == "payments" {
+			payments = about
+			break
+		}
+	}
+
+	require.NotEmpty(t, payments.ID)
+
+	creditCardsCount := 0
+
+	var creditCards gmaps.Option
+
+	for _, opt := range payments.Options {
+		if opt.Name == "Credit cards" {
+			creditCardsCount++
+			creditCards = opt
+		}
+	}
+
+	require.Equal(t, 1, creditCardsCount)
+	require.True(t, creditCards.Enabled)
+	require.Equal(t, []string{"American Express", "Diners Club", "Mastercard", "VISA"}, creditCards.Values)
+}
+
+func Test_EntryCSVIncludesCreditCardsAccepted(t *testing.T) {
+	entry := gmaps.Entry{
+		CreditCardsAccepted: []string{"American Express", "Mastercard", "VISA"},
+	}
+
+	require.Contains(t, entry.CsvHeaders(), "credit_cards_accepted")
+	require.Equal(t, len(entry.CsvHeaders()), len(entry.CsvRow()))
+	require.Equal(t,
+		"American Express, Mastercard, VISA",
+		entry.CsvRow()[slices.Index(entry.CsvHeaders(), "credit_cards_accepted")],
+	)
 }
 
 func Test_EntryMarshalEmitsBothLongitudeKeys(t *testing.T) {

--- a/internal/jsonbsanitize/entry.go
+++ b/internal/jsonbsanitize/entry.go
@@ -38,6 +38,7 @@ func StripNULFromEntry(entry *gmaps.Entry) {
 	entry.PlaceID = cleanString(entry.PlaceID)
 
 	cleanStringSlice(entry.Categories)
+	cleanStringSlice(entry.CreditCardsAccepted)
 	cleanStringSlice(entry.Emails)
 
 	entry.OpenHours = cleanOpenHours(entry.OpenHours)
@@ -146,6 +147,7 @@ func cleanAbout(items []gmaps.About) {
 
 		for j := range items[i].Options {
 			items[i].Options[j].Name = cleanString(items[i].Options[j].Name)
+			cleanStringSlice(items[i].Options[j].Values)
 		}
 	}
 }

--- a/internal/jsonbsanitize/entry_test.go
+++ b/internal/jsonbsanitize/entry_test.go
@@ -35,10 +35,11 @@ func TestStripNULFromEntry_NestedFields(t *testing.T) {
 				ID:   "about\x00",
 				Name: "about-name\x00",
 				Options: []gmaps.Option{
-					{Name: "opt\x00", Enabled: true},
+					{Name: "opt\x00", Enabled: true, Values: []string{"val\x00ue"}},
 				},
 			},
 		},
+		CreditCardsAccepted: []string{"VI\x00SA"},
 		UserReviews: []gmaps.Review{
 			{
 				Name:           "reviewer\x00",
@@ -69,6 +70,8 @@ func TestStripNULFromEntry_NestedFields(t *testing.T) {
 	require.Equal(t, "about", entry.About[0].ID)
 	require.Equal(t, "about-name", entry.About[0].Name)
 	require.Equal(t, "opt", entry.About[0].Options[0].Name)
+	require.Equal(t, []string{"value"}, entry.About[0].Options[0].Values)
+	require.Equal(t, []string{"VISA"}, entry.CreditCardsAccepted)
 	require.Equal(t, "reviewer", entry.UserReviews[0].Name)
 	require.Equal(t, "pp", entry.UserReviews[0].ProfilePicture)
 	require.Equal(t, "desc", entry.UserReviews[0].Description)

--- a/skills/google-maps-scraper/SKILL.md
+++ b/skills/google-maps-scraper/SKILL.md
@@ -239,7 +239,7 @@ These additional flags can be added to the docker command:
 ## CSV Columns Reference
 
 The full list of available CSV columns:
-`input_id`, `link`, `title`, `category`, `address`, `open_hours`, `popular_times`, `website`, `phone`, `plus_code`, `review_count`, `review_rating`, `reviews_per_rating`, `latitude`, `longitude`, `cid`, `status`, `description`, `reviews_link`, `thumbnail`, `timezone`, `price_range`, `data_id`, `images`, `reservations`, `order_online`, `menu`, `owner`, `complete_address`, `about`, `user_reviews`, `emails`
+`input_id`, `link`, `title`, `category`, `address`, `open_hours`, `popular_times`, `website`, `phone`, `plus_code`, `review_count`, `review_rating`, `reviews_per_rating`, `latitude`, `longitude`, `cid`, `status`, `description`, `reviews_link`, `thumbnail`, `timezone`, `price_range`, `data_id`, `street_view_url`, `place_id`, `images`, `reservations`, `order_online`, `menu`, `owner`, `complete_address`, `credit_cards_accepted`, `about`, `user_reviews`, `user_reviews_extended`, `emails`
 
 ## Error Handling
 


### PR DESCRIPTION
Google can return multiple payment option records with the same display name, notably "Credit cards". One record represents the general accepted payment method, while another carries the accepted card networks such as MasterCard or VISA. Because the scraper only exposed name/enabled, the second record was parsed as a duplicate disabled "Credit cards" option, which made the output misleading.

Preserves the card-network details in option values, expose them through a dedicated credit_cards_accepted field/CSV column, and merge duplicate about options so consumers see one enabled payment option with the available detail.