### PR TITLE
Add map view for scraped job places in the Web UI

### DIFF
--- a/web/places.go
+++ b/web/places.go
@@ -1,0 +1,124 @@
+package web
+
+import (
+	"context"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+)
+
+// ErrPlacesNotFound is returned by GetPlaces when the job's CSV output does not
+// exist. Callers use it to distinguish a missing job (404) from other errors.
+var ErrPlacesNotFound = errors.New("places not found")
+
+// Place is a single map-able result extracted from a job's CSV output.
+type Place struct {
+	Title        string  `json:"title"`
+	Address      string  `json:"address"`
+	Latitude     float64 `json:"latitude"`
+	Longitude    float64 `json:"longitude"`
+	Link         string  `json:"link"`
+	Category     string  `json:"category"`
+	Phone        string  `json:"phone"`
+	Website      string  `json:"website"`
+	ReviewRating float64 `json:"review_rating"`
+}
+
+// GetPlaces locates the job's CSV output and parses it into mappable places.
+// In web mode each job writes exactly one {id}.csv, so that file is the single
+// source of truth for the map.
+func (s *Service) GetPlaces(_ context.Context, id string) ([]Place, error) {
+	path, err := s.csvPath(id)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("csv file not found for job %s: %w", id, ErrPlacesNotFound)
+		}
+
+		return nil, err
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+
+	return parsePlaces(f)
+}
+
+// parsePlaces reads scraped results from a CSV stream and returns the places
+// that have valid coordinates. Columns are resolved by header name so the
+// parser tolerates reordering; the names mirror gmaps.Entry.CsvHeaders().
+func parsePlaces(r io.Reader) ([]Place, error) {
+	reader := csv.NewReader(r)
+	reader.FieldsPerRecord = -1
+
+	header, err := reader.Read()
+	if err != nil {
+		if err == io.EOF {
+			return []Place{}, nil
+		}
+
+		return nil, err
+	}
+
+	col := make(map[string]int, len(header))
+	for i, name := range header {
+		col[name] = i
+	}
+
+	get := func(row []string, name string) string {
+		idx, ok := col[name]
+		if !ok || idx >= len(row) {
+			return ""
+		}
+
+		return row[idx]
+	}
+
+	places := []Place{}
+
+	for {
+		row, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		lat, errLat := strconv.ParseFloat(get(row, "latitude"), 64)
+		lon, errLon := strconv.ParseFloat(get(row, "longitude"), 64)
+
+		if errLat != nil || errLon != nil {
+			continue
+		}
+
+		if lat == 0 && lon == 0 {
+			continue
+		}
+
+		rating, _ := strconv.ParseFloat(get(row, "review_rating"), 64)
+
+		places = append(places, Place{
+			Title:        get(row, "title"),
+			Address:      get(row, "address"),
+			Latitude:     lat,
+			Longitude:    lon,
+			Link:         get(row, "link"),
+			Category:     get(row, "category"),
+			Phone:        get(row, "phone"),
+			Website:      get(row, "website"),
+			ReviewRating: rating,
+		})
+	}
+
+	return places, nil
+}

--- a/web/places.go
+++ b/web/places.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strconv"
 )
@@ -101,11 +102,22 @@ func parsePlaces(r io.Reader) ([]Place, error) {
 			continue
 		}
 
+		if !finite(lat) || !finite(lon) {
+			continue
+		}
+
+		if lat < -90 || lat > 90 || lon < -180 || lon > 180 {
+			continue
+		}
+
 		if lat == 0 && lon == 0 {
 			continue
 		}
 
 		rating, _ := strconv.ParseFloat(get(row, "review_rating"), 64)
+		if !finite(rating) {
+			rating = 0
+		}
 
 		places = append(places, Place{
 			Title:        get(row, "title"),
@@ -121,4 +133,9 @@ func parsePlaces(r io.Reader) ([]Place, error) {
 	}
 
 	return places, nil
+}
+
+// finite reports whether f is a usable, real number (not NaN or ±Inf).
+func finite(f float64) bool {
+	return !math.IsNaN(f) && !math.IsInf(f, 0)
 }

--- a/web/service.go
+++ b/web/service.go
@@ -33,11 +33,10 @@ func (s *Service) Get(ctx context.Context, id string) (Job, error) {
 }
 
 func (s *Service) Delete(ctx context.Context, id string) error {
-	if strings.Contains(id, "/") || strings.Contains(id, "\\") || strings.Contains(id, "..") {
-		return fmt.Errorf("invalid file name")
+	datapath, err := s.csvPath(id)
+	if err != nil {
+		return err
 	}
-
-	datapath := filepath.Join(s.dataFolder, id+".csv")
 
 	if _, err := os.Stat(datapath); err == nil {
 		if err := os.Remove(datapath); err != nil {
@@ -58,12 +57,21 @@ func (s *Service) SelectPending(ctx context.Context) ([]Job, error) {
 	return s.repo.Select(ctx, SelectParams{Status: StatusPending, Limit: 1})
 }
 
-func (s *Service) GetCSV(_ context.Context, id string) (string, error) {
+// csvPath returns the on-disk path of a job's CSV output, rejecting ids that
+// could escape the data folder.
+func (s *Service) csvPath(id string) (string, error) {
 	if strings.Contains(id, "/") || strings.Contains(id, "\\") || strings.Contains(id, "..") {
 		return "", fmt.Errorf("invalid file name")
 	}
 
-	datapath := filepath.Join(s.dataFolder, id+".csv")
+	return filepath.Join(s.dataFolder, id+".csv"), nil
+}
+
+func (s *Service) GetCSV(_ context.Context, id string) (string, error) {
+	datapath, err := s.csvPath(id)
+	if err != nil {
+		return "", err
+	}
 
 	if _, err := os.Stat(datapath); os.IsNotExist(err) {
 		return "", fmt.Errorf("csv file not found for job %s", id)

--- a/web/service_test.go
+++ b/web/service_test.go
@@ -68,6 +68,34 @@ func TestGetPlacesSkipsRowsWithoutCoords(t *testing.T) {
 	}
 }
 
+func TestGetPlacesSkipsNonFiniteAndOutOfRangeCoords(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewService(nil, dir)
+
+	csv := "title,latitude,longitude,review_rating\n" +
+		"NaN,NaN,2.5,3\n" +
+		"Inf,Inf,2.5,3\n" +
+		"OutOfRange,91,200,3\n" +
+		"BadRating,1.5,2.5,NaN\n" +
+		"Good,1.5,2.5,4.5\n"
+	writeCSV(t, dir, "job-nf", csv)
+
+	places, err := svc.GetPlaces(context.Background(), "job-nf")
+	if err != nil {
+		t.Fatalf("GetPlaces: %v", err)
+	}
+
+	if len(places) != 2 {
+		t.Fatalf("expected 2 places (BadRating + Good), got %d: %+v", len(places), places)
+	}
+
+	for _, p := range places {
+		if p.Title == "BadRating" && p.ReviewRating != 0 {
+			t.Fatalf("non-finite rating should be sanitized to 0, got %v", p.ReviewRating)
+		}
+	}
+}
+
 func TestGetPlacesMissingCSV(t *testing.T) {
 	svc := NewService(nil, t.TempDir())
 

--- a/web/service_test.go
+++ b/web/service_test.go
@@ -1,0 +1,85 @@
+//nolint:testpackage // shares the internal web test package with web_test.go
+package web
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeCSV(t *testing.T, dir, id, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, id+".csv"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write csv: %v", err)
+	}
+}
+
+func TestGetPlacesParsesCSV(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewService(nil, dir)
+
+	csv := "title,address,latitude,longitude,link,category,phone,website,review_rating\n" +
+		"Coffee Place,1 Main St,37.7749,-122.4194,http://maps/1,cafe,555,http://web,4.5\n"
+	writeCSV(t, dir, "job-1", csv)
+
+	places, err := svc.GetPlaces(context.Background(), "job-1")
+	if err != nil {
+		t.Fatalf("GetPlaces: %v", err)
+	}
+
+	if len(places) != 1 {
+		t.Fatalf("expected 1 place, got %d", len(places))
+	}
+
+	p := places[0]
+	if p.Title != "Coffee Place" || p.Latitude != 37.7749 || p.Longitude != -122.4194 {
+		t.Fatalf("unexpected place: %+v", p)
+	}
+
+	if p.ReviewRating != 4.5 {
+		t.Fatalf("unexpected rating: %v", p.ReviewRating)
+	}
+}
+
+func TestGetPlacesSkipsRowsWithoutCoords(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewService(nil, dir)
+
+	csv := "title,latitude,longitude\n" +
+		"No Coords,,\n" +
+		"Zero,0,0\n" +
+		"Bad,abc,def\n" +
+		"Good,1.5,2.5\n"
+	writeCSV(t, dir, "job-2", csv)
+
+	places, err := svc.GetPlaces(context.Background(), "job-2")
+	if err != nil {
+		t.Fatalf("GetPlaces: %v", err)
+	}
+
+	if len(places) != 1 {
+		t.Fatalf("expected 1 place, got %d", len(places))
+	}
+
+	if places[0].Title != "Good" {
+		t.Fatalf("unexpected place: %+v", places[0])
+	}
+}
+
+func TestGetPlacesMissingCSV(t *testing.T) {
+	svc := NewService(nil, t.TempDir())
+
+	if _, err := svc.GetPlaces(context.Background(), "missing"); err == nil {
+		t.Fatal("expected error for missing csv")
+	}
+}
+
+func TestGetPlacesRejectsTraversal(t *testing.T) {
+	svc := NewService(nil, t.TempDir())
+
+	if _, err := svc.GetPlaces(context.Background(), "../etc/passwd"); err == nil {
+		t.Fatal("expected error for path traversal")
+	}
+}

--- a/web/static/css/main.css
+++ b/web/static/css/main.css
@@ -355,3 +355,112 @@ nav a:hover {
     transform: translateY(-1px);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
+
+/* Job map view */
+.view-button {
+    background-color: #2c7be5;
+    color: #fff;
+    padding: 6px 12px;
+    font-size: 12px;
+}
+
+.view-button:hover {
+    background-color: #1a68d1;
+}
+
+.map-modal {
+    display: flex;
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background: rgba(0, 0, 0, 0.6);
+    justify-content: center;
+    align-items: center;
+}
+
+.map-modal-content {
+    background: #fff;
+    width: 90vw;
+    height: 85vh;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.map-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.map-modal-header h2 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.map-modal-close {
+    background: none;
+    border: none;
+    font-size: 1.6rem;
+    line-height: 1;
+    cursor: pointer;
+    color: #555;
+}
+
+.map-modal-body {
+    flex: 1;
+    display: flex;
+    min-height: 0;
+}
+
+#job-map {
+    flex: 3;
+    height: 100%;
+}
+
+#job-places-list {
+    flex: 1;
+    min-width: 240px;
+    max-width: 360px;
+    overflow-y: auto;
+    border-left: 1px solid #e0e0e0;
+    padding: 8px;
+}
+
+.place-item {
+    padding: 8px;
+    border-bottom: 1px solid #f0f0f0;
+    cursor: pointer;
+}
+
+.place-item:hover {
+    background: #f5f8ff;
+}
+
+.place-title {
+    font-weight: 600;
+}
+
+.place-address {
+    font-size: 0.85rem;
+    color: #666;
+}
+
+.place-rating {
+    font-size: 0.85rem;
+    color: #d98300;
+}
+
+.map-loading,
+.map-empty,
+.map-error {
+    padding: 12px;
+    color: #666;
+}
+
+.map-error {
+    color: #c0392b;
+}

--- a/web/static/templates/index.html
+++ b/web/static/templates/index.html
@@ -147,6 +147,7 @@
         </main>
     </div>
 
+    <div id="map-modal-container"></div>
 <script>
 function hideSponsor() {
     const sponsorSection = document.getElementById('sponsor-section');

--- a/web/static/templates/job_rows.html
+++ b/web/static/templates/job_rows.html
@@ -8,6 +8,10 @@
     </td>
     <td>
         {{ if eq .Status "ok" }}
+            <button type="button" class="button view-button"
+                    hx-get="/view?id={{.ID}}"
+                    hx-target="#map-modal-container"
+                    hx-swap="innerHTML">View</button>
             <a href="/download?id={{.ID}}" download class="button download-button">Download</a>
         {{ end }}
         <button hx-delete="/delete?id={{.ID}}" 

--- a/web/static/templates/job_view.html
+++ b/web/static/templates/job_view.html
@@ -1,8 +1,8 @@
-<div id="map-modal" class="map-modal" onclick="if(event.target===this)closeJobMap()">
+<div id="map-modal" class="map-modal" role="dialog" aria-modal="true" aria-labelledby="map-modal-title" onclick="if(event.target===this)closeJobMap()">
     <div class="map-modal-content">
         <div class="map-modal-header">
-            <h2>Places</h2>
-            <button type="button" class="map-modal-close" onclick="closeJobMap()">&times;</button>
+            <h2 id="map-modal-title">Places</h2>
+            <button type="button" class="map-modal-close" aria-label="Close" onclick="closeJobMap()">&times;</button>
         </div>
         <div class="map-modal-body">
             <div id="job-map"></div>

--- a/web/static/templates/job_view.html
+++ b/web/static/templates/job_view.html
@@ -1,0 +1,139 @@
+<div id="map-modal" class="map-modal" onclick="if(event.target===this)closeJobMap()">
+    <div class="map-modal-content">
+        <div class="map-modal-header">
+            <h2>Places</h2>
+            <button type="button" class="map-modal-close" onclick="closeJobMap()">&times;</button>
+        </div>
+        <div class="map-modal-body">
+            <div id="job-map"></div>
+            <div id="job-places-list"></div>
+        </div>
+    </div>
+    <script>
+    (function () {
+        var places = {{ . }};
+
+        var LEAFLET_CSS = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css';
+        var LEAFLET_JS = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js';
+
+        // ensureLeaflet lazily loads Leaflet (CSS + JS) the first time the map
+        // is opened, then invokes callback once it is available.
+        function ensureLeaflet(callback) {
+            if (window.L) {
+                callback();
+                return;
+            }
+
+            if (!document.getElementById('leaflet-css')) {
+                var link = document.createElement('link');
+                link.id = 'leaflet-css';
+                link.rel = 'stylesheet';
+                link.href = LEAFLET_CSS;
+                document.head.appendChild(link);
+            }
+
+            var script = document.getElementById('leaflet-js');
+            if (!script) {
+                script = document.createElement('script');
+                script.id = 'leaflet-js';
+                script.src = LEAFLET_JS;
+                document.head.appendChild(script);
+            }
+
+            script.addEventListener('load', callback);
+        }
+
+        function escapeHtml(str) {
+            var div = document.createElement('div');
+            div.textContent = str == null ? '' : str;
+            return div.innerHTML;
+        }
+
+        function createMap() {
+            if (window.__jobMap) {
+                window.__jobMap.remove();
+            }
+
+            var map = L.map('job-map');
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                maxZoom: 19,
+                attribution: '© OpenStreetMap contributors'
+            }).addTo(map);
+
+            window.__jobMap = map;
+            return map;
+        }
+
+        function placePopup(place) {
+            var parts = ['<strong>' + escapeHtml(place.title) + '</strong>'];
+            if (place.address) {
+                parts.push(escapeHtml(place.address));
+            }
+            if (place.link && /^https?:\/\//i.test(place.link)) {
+                parts.push('<a href="' + encodeURI(place.link) + '" target="_blank" rel="noopener noreferrer">View on Google Maps</a>');
+            }
+            return parts.join('<br>');
+        }
+
+        function placeListItem(place, onSelect) {
+            var item = document.createElement('div');
+            item.className = 'place-item';
+            item.innerHTML = '<div class="place-title">' + escapeHtml(place.title) + '</div>' +
+                (place.address ? '<div class="place-address">' + escapeHtml(place.address) + '</div>' : '') +
+                (place.review_rating ? '<div class="place-rating">★ ' + escapeHtml(String(place.review_rating)) + '</div>' : '');
+            item.addEventListener('click', onSelect);
+            return item;
+        }
+
+        function renderPlaces(map, listEl) {
+            var bounds = [];
+
+            places.forEach(function (place) {
+                var latlng = [place.latitude, place.longitude];
+                bounds.push(latlng);
+
+                L.marker(latlng).bindPopup(placePopup(place)).addTo(map);
+                listEl.appendChild(placeListItem(place, function () {
+                    map.setView(latlng, 16);
+                }));
+            });
+
+            map.fitBounds(bounds, { padding: [30, 30] });
+            setTimeout(function () { map.invalidateSize(); }, 0);
+        }
+
+        function showEmptyState(map, listEl) {
+            listEl.innerHTML = '<p class="map-empty">No places with coordinates were found for this job.</p>';
+            map.setView([0, 0], 2);
+        }
+
+        function initJobMap() {
+            var listEl = document.getElementById('job-places-list');
+            var map = createMap();
+
+            listEl.innerHTML = '';
+
+            if (places.length === 0) {
+                showEmptyState(map, listEl);
+                return;
+            }
+
+            renderPlaces(map, listEl);
+        }
+
+        window.closeJobMap = function () {
+            if (window.__jobMap) {
+                window.__jobMap.remove();
+                window.__jobMap = null;
+            }
+
+            var container = document.getElementById('map-modal-container');
+            if (container) {
+                container.innerHTML = '';
+            }
+        };
+
+        ensureLeaflet(initJobMap);
+    })();
+    </script>
+</div>

--- a/web/web.go
+++ b/web/web.go
@@ -591,13 +591,18 @@ func (s *Server) apiGetJob(w http.ResponseWriter, r *http.Request) {
 // viewJob renders the map modal fragment for a job, embedding the job's places
 // directly so the client needs no separate data request.
 func (s *Server) viewJob(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+
+		return
+	}
+
 	id, ok := getIDFromRequest(r)
 	if !ok {
 		http.Error(w, "Invalid ID", http.StatusUnprocessableEntity)
 
 		return
 	}
-
 	places, err := s.svc.GetPlaces(r.Context(), id.String())
 	if err != nil {
 		if !errors.Is(err, ErrPlacesNotFound) {

--- a/web/web.go
+++ b/web/web.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"encoding/json"
@@ -603,7 +604,9 @@ func (s *Server) viewJob(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
+
 	places, err := s.svc.GetPlaces(r.Context(), id.String())
+
 	if err != nil {
 		if !errors.Is(err, ErrPlacesNotFound) {
 			log.Printf("view job %s: %v", id, err)
@@ -623,7 +626,15 @@ func (s *Server) viewJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = tmpl.Execute(w, places)
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, places); err != nil {
+		log.Printf("view job %s: render: %v", id, err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	_, _ = buf.WriteTo(w)
 }
 
 func (s *Server) apiDeleteJob(w http.ResponseWriter, r *http.Request) {

--- a/web/web.go
+++ b/web/web.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -63,6 +64,11 @@ func New(svc *Service, addr string) (*Server, error) {
 		ans.delete(w, r)
 	})
 	mux.HandleFunc("/jobs", ans.getJobs)
+	mux.HandleFunc("/view", func(w http.ResponseWriter, r *http.Request) {
+		r = requestWithID(r)
+
+		ans.viewJob(w, r)
+	})
 	mux.HandleFunc("/", ans.index)
 
 	// api routes
@@ -125,6 +131,7 @@ func New(svc *Service, addr string) (*Server, error) {
 		"static/templates/index.html",
 		"static/templates/job_rows.html",
 		"static/templates/job_row.html",
+		"static/templates/job_view.html",
 		"static/templates/redoc.html",
 	}
 
@@ -581,6 +588,38 @@ func (s *Server) apiGetJob(w http.ResponseWriter, r *http.Request) {
 	renderJSON(w, http.StatusOK, job)
 }
 
+// viewJob renders the map modal fragment for a job, embedding the job's places
+// directly so the client needs no separate data request.
+func (s *Server) viewJob(w http.ResponseWriter, r *http.Request) {
+	id, ok := getIDFromRequest(r)
+	if !ok {
+		http.Error(w, "Invalid ID", http.StatusUnprocessableEntity)
+
+		return
+	}
+
+	places, err := s.svc.GetPlaces(r.Context(), id.String())
+	if err != nil {
+		if !errors.Is(err, ErrPlacesNotFound) {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
+
+		// No CSV yet: render the modal with an empty state rather than an error.
+		places = []Place{}
+	}
+
+	tmpl, ok := s.tmpl["static/templates/job_view.html"]
+	if !ok {
+		http.Error(w, "missing tpl", http.StatusInternalServerError)
+
+		return
+	}
+
+	_ = tmpl.Execute(w, places)
+}
+
 func (s *Server) apiDeleteJob(w http.ResponseWriter, r *http.Request) {
 	id, ok := getIDFromRequest(r)
 	if !ok {
@@ -629,8 +668,8 @@ func securityHeaders(next http.Handler) http.Handler {
 			"default-src 'self'; "+
 				"script-src 'self' cdn.redoc.ly cdnjs.cloudflare.com 'unsafe-inline' 'unsafe-eval'; "+
 				"worker-src 'self' blob:; "+
-				"style-src 'self' 'unsafe-inline' fonts.googleapis.com; "+
-				"img-src 'self' data: cdn.redoc.ly; "+
+				"style-src 'self' 'unsafe-inline' fonts.googleapis.com cdnjs.cloudflare.com; "+
+				"img-src 'self' data: cdn.redoc.ly cdnjs.cloudflare.com *.tile.openstreetmap.org; "+
 				"font-src 'self' fonts.gstatic.com; "+
 				"connect-src 'self'")
 

--- a/web/web.go
+++ b/web/web.go
@@ -606,7 +606,8 @@ func (s *Server) viewJob(w http.ResponseWriter, r *http.Request) {
 	places, err := s.svc.GetPlaces(r.Context(), id.String())
 	if err != nil {
 		if !errors.Is(err, ErrPlacesNotFound) {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			log.Printf("view job %s: %v", id, err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
 
 			return
 		}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -1,0 +1,96 @@
+//nolint:testpackage // tests unexported handlers (viewJob, requestWithID, securityHeaders) directly
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTestServer(t *testing.T, dir string) *Server {
+	t.Helper()
+
+	srv, err := New(NewService(nil, dir), ":0")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	return srv
+}
+
+func TestViewJobRendersPlaces(t *testing.T) {
+	dir := t.TempDir()
+	id := "11111111-1111-1111-1111-111111111111"
+
+	csv := "title,latitude,longitude\nPlace,1.5,2.5\n"
+	if err := os.WriteFile(filepath.Join(dir, id+".csv"), []byte(csv), 0o600); err != nil {
+		t.Fatalf("write csv: %v", err)
+	}
+
+	srv := newTestServer(t, dir)
+
+	req := requestWithID(httptest.NewRequest(http.MethodGet, "/view?id="+id, http.NoBody))
+	rec := httptest.NewRecorder()
+	srv.viewJob(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{`id="map-modal"`, `initJobMap()`, `"title":"Place"`, `"latitude":1.5`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestViewJobEmptyState(t *testing.T) {
+	srv := newTestServer(t, t.TempDir())
+
+	id := "22222222-2222-2222-2222-222222222222"
+	req := requestWithID(httptest.NewRequest(http.MethodGet, "/view?id="+id, http.NoBody))
+	rec := httptest.NewRecorder()
+	srv.viewJob(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "var places = [];") {
+		t.Fatalf("expected empty places array, got:\n%s", body)
+	}
+}
+
+func TestViewJobInvalidID(t *testing.T) {
+	srv := newTestServer(t, t.TempDir())
+
+	req := requestWithID(httptest.NewRequest(http.MethodGet, "/view?id=not-a-uuid", http.NoBody))
+	rec := httptest.NewRecorder()
+	srv.viewJob(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", rec.Code)
+	}
+}
+
+func TestSecurityHeadersAllowMapResources(t *testing.T) {
+	handler := securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	for _, want := range []string{"tile.openstreetmap.org", "cdnjs.cloudflare.com"} {
+		if !strings.Contains(csp, want) {
+			t.Fatalf("CSP missing %q: %s", want, csp)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **View** action to each completed (`ok`) job in the Web UI that opens a modal with a map plotting every geocoded place found in that job, alongside a synced list.
<img width="1879" height="1040" alt="image" src="https://github.com/user-attachments/assets/e7a8baf2-0bd5-4b8f-b362-cc3f5c482d93" />

## How it works

- New `GET /view?id=...` renders a self-contained HTMX fragment (`web/static/templates/job_view.html`). The job's places are parsed from its `{id}.csv` and embedded into the fragment at render time via `html/template` JSON marshaling — no separate JSON endpoint or client-side fetch.
- The fragment lazy-loads Leaflet (CSS/JS from cdnjs) only on first map open, then plots OpenStreetMap markers; clicking a list item recenters the map.
- `Service.GetPlaces` parses the CSV into `[]Place`, skipping rows without valid coordinates; parsing lives in `web/places.go` with a pure `parsePlaces(io.Reader)` helper, and the column names mirror `gmaps.Entry.CsvHeaders()`.
- Content-Security-Policy widened to allow Leaflet (`cdnjs.cloudflare.com`) and OSM tiles (`*.tile.openstreetmap.org`).
- Scraped fields are HTML-escaped before rendering, and place links are restricted to `http(s)` to avoid `javascript:` URL injection.

Web mode always writes a single `{id}.csv` per job, so the CSV is the source of truth; no new result writer is introduced and other runner modes are unaffected (the View UI only exists in `-web` mode).

Also bumps `jackc/pgx/v5` to `v5.9.2` to clear a govulncheck advisory (GO-2026-5004) that otherwise fails CI.

## Test Plan

- [x] `go test ./web/` — unit tests for `GetPlaces` (parse, skip coord-less rows, missing file, path traversal) and the `/view` fragment (places embedded, empty state, invalid id) plus CSP.
- [x] `make lint`, `make vuln`, `go vet`, `gofmt`, `go build ./...` — all clean.
- [x] Manual: ran `-web`, confirmed the View button on completed jobs opens the modal, markers render, and the empty state shows when a job has no geocoded places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)