### PR TITLE
fix(gmaps): read business closure badge from [88][0]

### DIFF
--- a/gmaps/entry.go
+++ b/gmaps/entry.go
@@ -418,7 +418,7 @@ func EntryFromJSON(raw []byte, reviewCountOnly ...bool) (entry Entry, err error)
 	entry.Latitude = getNthElementAndCast[float64](darray, 9, 2)
 	entry.Longtitude = getNthElementAndCast[float64](darray, 9, 3)
 	entry.Cid = getNthElementAndCast[string](jd, 25, 3, 0, 13, 0, 0, 1)
-	entry.Status = getNthElementAndCast[string](darray, 34, 4, 4)
+	entry.Status = extractPlaceStatus(darray)
 	entry.Description = getNthElementAndCast[string](darray, 32, 1, 1)
 	entry.ReviewsLink = getNthElementAndCast[string](darray, 4, 3, 0)
 	entry.Thumbnail = getNthElementAndCast[string](darray, 72, 0, 1, 6, 0)
@@ -852,6 +852,31 @@ func getPopularTimes(darray []any) map[string]map[int]int {
 	}
 
 	return popularTimes
+}
+
+// extractPlaceStatus returns the business-closure badge at [88][0] when present
+// (e.g. "CLOSED", "ĐANG ĐÓNG CỬA"). Otherwise it falls back to the open-hours
+// summary at [34][4][4] (e.g. "Closed ⋅ Opens 12:30 pm Tue").
+func extractPlaceStatus(darray []any) string {
+	if badge := getNthElementAndCast[string](darray, 88, 0); isBusinessClosedBadge(badge) {
+		return "closed"
+	}
+
+	return getNthElementAndCast[string](darray, 34, 4, 4)
+}
+
+func isBusinessClosedBadge(badge string) bool {
+	if badge == "" {
+		return false
+	}
+
+	if strings.EqualFold(strings.TrimSpace(badge), "closed") {
+		return true
+	}
+
+	lower := strings.ToLower(badge)
+
+	return strings.Contains(lower, "đóng cửa")
 }
 
 func getNthElementAndCast[T any](arr []any, indexes ...int) T {

--- a/gmaps/entry_internal_test.go
+++ b/gmaps/entry_internal_test.go
@@ -7,6 +7,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExtractPlaceStatus(t *testing.T) {
+	t.Run("business closed badge", func(t *testing.T) {
+		darray := make([]any, 89)
+		darray[88] = []any{"CLOSED", "SearchResult.TYPE_COFFEE", nil, "Song Coffee", nil}
+		darray[34] = []any{nil, nil, nil, nil, []any{nil, nil, nil, nil, "Closed ⋅ Opens 8 am Mon"}}
+
+		require.Equal(t, "closed", extractPlaceStatus(darray))
+	})
+
+	t.Run("open hours summary when no closure badge", func(t *testing.T) {
+		darray := make([]any, 89)
+		darray[88] = []any{nil, "SearchResult.TYPE_RESTAURANT", nil, "Kipriakon", nil}
+		darray[34] = []any{nil, nil, nil, nil, []any{nil, nil, nil, nil, "Closed ⋅ Opens 12:30 pm Tue"}}
+
+		require.Equal(t, "Closed ⋅ Opens 12:30 pm Tue", extractPlaceStatus(darray))
+	})
+
+	t.Run("localized closure badge", func(t *testing.T) {
+		darray := make([]any, 89)
+		darray[88] = []any{"ĐANG ĐÓNG CỬA", "SearchResult.TYPE_COFFEE", nil, "Song Coffee", nil}
+
+		require.Equal(t, "closed", extractPlaceStatus(darray))
+	})
+}
+
 func TestParseReviewsRelativeDatePaths(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/gmaps/multiple.go
+++ b/gmaps/multiple.go
@@ -68,7 +68,7 @@ func ParseSearchResults(raw []byte) ([]*Entry, error) {
 		entry.Longtitude = getNthElementAndCast[float64](business, 9, 3)
 		entry.Phone = strings.ReplaceAll(getNthElementAndCast[string](business, 178, 0, 0), " ", "")
 		entry.OpenHours = getHours(business)
-		entry.Status = getNthElementAndCast[string](business, 34, 4, 4)
+		entry.Status = extractPlaceStatus(business)
 		entry.Timezone = getNthElementAndCast[string](business, 30)
 		entry.DataID = getNthElementAndCast[string](business, 10)
 


### PR DESCRIPTION
## Summary

- Fix `status` parsing for permanently/temporarily closed places
- Google Maps exposes the closure badge at `[6][88][0]` (e.g. `CLOSED`, `ĐANG ĐÓNG CỬA`)
- The scraper was reading `[6][34][4][4]`, which is the open-hours summary (e.g. `Closed · Opens 12:30 pm Tue`), not the business closure badge
- Add `extractPlaceStatus()` that prefers `[88][0]` and falls back to `[34][4][4]` when no closure badge is present

## Test plan

- [x] `go test ./gmaps/...`
- [x] New unit tests for closure badge, localized badge, and open-hours fallback
- [x] Existing `Test_EntryFromJSON` still passes (Kipriakon fixture uses hours summary when `[88][0]` is empty)