### PR TITLE
Fall back to [88][0] for place status when [34][4][4] is empty

### DIFF
--- a/gmaps/entry.go
+++ b/gmaps/entry.go
@@ -419,6 +419,10 @@ func EntryFromJSON(raw []byte, reviewCountOnly ...bool) (entry Entry, err error)
 	entry.Longtitude = getNthElementAndCast[float64](darray, 9, 3)
 	entry.Cid = getNthElementAndCast[string](jd, 25, 3, 0, 13, 0, 0, 1)
 	entry.Status = getNthElementAndCast[string](darray, 34, 4, 4)
+	if entry.Status == "" {
+		// [34][4][4] went dead ~2026-07; closed-state enum now at [88][0] ("CLOSED" / null)
+		entry.Status = getNthElementAndCast[string](darray, 88, 0)
+	}
 	entry.Description = getNthElementAndCast[string](darray, 32, 1, 1)
 	entry.ReviewsLink = getNthElementAndCast[string](darray, 4, 3, 0)
 	entry.Thumbnail = getNthElementAndCast[string](darray, 72, 0, 1, 6, 0)

--- a/gmaps/entry_test.go
+++ b/gmaps/entry_test.go
@@ -312,3 +312,17 @@ func Test_EntryFromJsonC(t *testing.T) {
 		fmt.Printf("%+v\n", entry)
 	}
 }
+
+func Test_EntryFromJSONStatusFallback(t *testing.T) {
+	// Places where [34][4][4] is absent carry the closed-state enum at [88][0].
+	darray := make([]any, 89)
+	darray[88] = []any{"CLOSED"}
+	jd := []any{nil, nil, nil, nil, nil, nil, darray}
+
+	raw, err := json.Marshal(jd)
+	require.NoError(t, err)
+
+	entry, err := gmaps.EntryFromJSON(raw)
+	require.NoError(t, err)
+	require.Equal(t, "CLOSED", entry.Status)
+}


### PR DESCRIPTION
## Problem

Google Maps place blobs stopped populating the human-readable status at `darray[34][4][4]` (observed ~July 2026). Permanently-closed places now only carry a machine enum (`"CLOSED"`, `null` when open) at `darray[88][0]`. Without it, closed places scrape with an empty `status` column and are indistinguishable from open ones.

Found while scraping ~1,000 Kenyan gyms: dozens of permanently-closed places came through with empty status, all of them carrying `"CLOSED"` at `[88][0]` in the raw blob.

## Change

- `EntryFromJSON`: when `[34][4][4]` yields an empty string, read `[88][0]`. Old blobs still populate `[34][4][4]`, so it stays the primary source — the existing `testdata/raw.json` fixture is unaffected and the human-readable strings ("Closed ⋅ Opens 12:30 pm Tue") keep working where Google still sends them.
- Test: `Test_EntryFromJSONStatusFallback` with a minimal synthetic blob exercising the fallback path.

`go test ./gmaps/`, `go vet`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)