### PR TITLE
Dockerfile: bake the Playwright 1.60.0 driver the runtime requires

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,24 @@ RUN export PATH=$PATH:/usr/local/go/bin:/root/go/bin \
     && rm -rf /var/lib/apt/lists/* \
     && go install github.com/mxschmitt/playwright-go/cmd/playwright@${PLAYWRIGHT_GO_VERSION} \
     && mkdir -p /opt/browsers \
-    && playwright install chromium --with-deps
+    && playwright install chromium --with-deps \
+    # The scraping runtime pulls in playwright-community/playwright-go v0.6000.0
+    # transitively (via scrapemate), which requires Playwright driver v1.60.0.
+    # That version's legacy driver download (playwright.azureedge.net) now 404s,
+    # so every browser scrape fails with:
+    #   "could not install driver: driver exists but version not 1.60.0".
+    # The community fork cannot be bumped to a fixed release either: its v0.61xx
+    # tags redeclare the module path as github.com/mxschmitt/playwright-go, so Go
+    # rejects them under the community import path. Until scrapemate migrates,
+    # supply the exact driver the runtime validates against from npm (still
+    # served), then fetch the Chromium build v1.60.0 pins. The runtime only
+    # checks `node package/cli.js --version == 1.60.0` before launching.
+    && curl -fsSL https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz -o /tmp/pw-core.tgz \
+    && rm -rf /opt/ms-playwright-go/package \
+    && tar -xzf /tmp/pw-core.tgz -C /opt/ms-playwright-go \
+    && rm /tmp/pw-core.tgz \
+    && /opt/ms-playwright-go/node /opt/ms-playwright-go/package/cli.js --version | grep -q 1.60.0 \
+    && /opt/ms-playwright-go/node /opt/ms-playwright-go/package/cli.js install chromium
 
 # Build stage
 FROM golang:1.26.5-trixie AS builder


### PR DESCRIPTION
## Problem

Browser scraping fails on a freshly built image (and on `gosom/google-maps-scraper:latest`). Every job errors immediately and then hangs in `working` forever:

```
error scraping job ...: could not install driver: could not install driver:
driver exists but version not 1.60.0 in : /opt/ms-playwright-go
```

## Root cause

Two different `playwright-go` forks are in play, expecting two different driver versions:

- **Runtime** (the code that actually launches the browser): `runner → scrapemate v1.2.1 → github.com/playwright-community/playwright-go v0.6000.0`, which pins Playwright driver **1.60.0**.
- **Installer / Dockerfile**: `github.com/mxschmitt/playwright-go v0.6100.0`, which installs driver **1.61.1**.

The image therefore bakes driver **1.61.1**, but the runtime demands **1.60.0** and refuses to run against anything else. To make it worse, the community fork can only fetch its 1.60.0 driver from `playwright.azureedge.net`, which Microsoft has decommissioned — that URL (and the akamai/verizon variants) now return **404**, so the runtime cannot self-heal by downloading it either.

The community fork also cannot simply be bumped to a fixed release: its `v0.61xx` tags redeclare the module path as `github.com/mxschmitt/playwright-go`, so Go rejects them under the `playwright-community` import path:

```
module declares its path as: github.com/mxschmitt/playwright-go
        but was required as: github.com/playwright-community/playwright-go
```

So until `scrapemate` migrates off the community import path, the runtime is stuck requiring driver 1.60.0.

## Fix

The runtime's only gate before launching Chromium is `node package/cli.js --version == 1.60.0`. The 1.60.0 driver payload is just the `playwright-core` npm package, which is still served. So in the `playwright-deps` stage we overlay that package from npm onto the baked driver and fetch the Chromium build 1.60.0 pins:

```dockerfile
&& curl -fsSL https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz -o /tmp/pw-core.tgz \
&& rm -rf /opt/ms-playwright-go/package \
&& tar -xzf /tmp/pw-core.tgz -C /opt/ms-playwright-go \
&& rm /tmp/pw-core.tgz \
&& /opt/ms-playwright-go/node /opt/ms-playwright-go/package/cli.js --version | grep -q 1.60.0 \
&& /opt/ms-playwright-go/node /opt/ms-playwright-go/package/cli.js install chromium
```

No source or dependency changes — the baked driver now matches what the runtime validates against. The `grep -q 1.60.0` acts as a build-time assertion so the build fails loudly if the driver version ever drifts again.

## Verification

Built the image from this branch and ran a real scrape (web mode, `POST /api/v1/jobs`, `fast_mode: false`). Jobs now complete with `status: ok` and return full place data (name, address, place_id, phone, hours, coordinates) — e.g. Google Maps searches for solar installers in Berlin returned populated CSVs. Before this change the identical job failed with the driver error above.

## Note

This is a build-time workaround scoped to the Dockerfile. The cleaner long-term fix is for `scrapemate` to move to the `mxschmitt/playwright-go` fork (or a community release that keeps the `playwright-community` module path and a live download source), after which the runtime and installer can share a single driver version and this overlay can be dropped.
