### PR TITLE
Fix DOM-extracted extended reviews

### DIFF
--- a/gmaps/dom_reviews_test.go
+++ b/gmaps/dom_reviews_test.go
@@ -1,0 +1,100 @@
+//nolint:testpackage // we need to test unexported functions in the same package
+package gmaps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_decodeDOMReviews(t *testing.T) {
+	const reviewID = "ChZDSUhNMG9nS0VJQ0FnSUR2c0tYWVh3EAE"
+
+	tests := []struct {
+		name string
+		raw  map[string]any
+		want DOMReview
+	}{
+		{"int rating", map[string]any{"rating": 5}, DOMReview{Rating: 5}},
+		{"float rating", map[string]any{"rating": 4.0}, DOMReview{Rating: 4}},
+		{"rating above scale", map[string]any{"rating": 12}, DOMReview{}},
+		{"negative rating", map[string]any{"rating": -3}, DOMReview{}},
+		{"string rating", map[string]any{"rating": "5"}, DOMReview{}},
+		{"bool rating", map[string]any{"rating": true}, DOMReview{}},
+		{"nil rating", map[string]any{"rating": nil}, DOMReview{}},
+		{"missing rating", map[string]any{}, DOMReview{}},
+		{"review id", map[string]any{"review_id": reviewID}, DOMReview{ReviewID: reviewID}},
+		{"empty review id", map[string]any{"review_id": ""}, DOMReview{}},
+		{"missing review id", map[string]any{"rating": 3}, DOMReview{Rating: 3}},
+		{
+			"author and relative time",
+			map[string]any{"author_name": "Reviewer A", "relative_time_description": "a year ago"},
+			DOMReview{AuthorName: "Reviewer A", RelativeTimeDescription: "a year ago"},
+		},
+	}
+
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			got := decodeDOMReviews([]any{tt.raw})
+			require.Len(t, got, 1)
+			assert.Equal(t, tt.want, got[0])
+		})
+	}
+}
+
+func Test_ConvertDOMReviewsToReviews(t *testing.T) {
+	const reviewID = "ChZDSUhNMG9nS0VJQ0FnSUR2c0tYWVh3EAE"
+
+	got := ConvertDOMReviewsToReviews([]DOMReview{
+		{
+			ReviewID:                reviewID,
+			AuthorName:              "Reviewer A",
+			Rating:                  5,
+			RelativeTimeDescription: "3 months ago",
+		},
+		{Rating: 4},
+	})
+
+	require.Len(t, got, 1)
+	assert.Equal(t, reviewID, got[0].ReviewID)
+	assert.Equal(t, 5, got[0].Rating)
+	assert.Equal(t, "Reviewer A", got[0].Name)
+	assert.Equal(t, "3 months ago", got[0].When)
+}
+
+func Test_dedupeDOMReviewsAgainstPrimary(t *testing.T) {
+	tests := []struct {
+		name    string
+		primary []Review
+		dom     []Review
+		want    []Review
+	}{
+		{
+			"matching id dropped",
+			[]Review{{ReviewID: "id-1"}, {ReviewID: "id-2"}},
+			[]Review{{ReviewID: "id-1"}, {ReviewID: "id-3"}},
+			[]Review{{ReviewID: "id-3"}},
+		},
+		{
+			"unmatched ids kept",
+			[]Review{{ReviewID: "id-1"}},
+			[]Review{{ReviewID: "id-2"}, {ReviewID: "id-3"}},
+			[]Review{{ReviewID: "id-2"}, {ReviewID: "id-3"}},
+		},
+		{
+			"empty ids never match",
+			[]Review{{ReviewID: ""}, {ReviewID: "id-1"}},
+			[]Review{{ReviewID: ""}, {ReviewID: ""}},
+			[]Review{{ReviewID: ""}, {ReviewID: ""}},
+		},
+	}
+
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, dedupeDOMReviewsAgainstPrimary(tt.primary, tt.dom))
+		})
+	}
+}

--- a/gmaps/place.go
+++ b/gmaps/place.go
@@ -3,6 +3,7 @@ package gmaps
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -118,7 +119,14 @@ func (j *PlaceJob) Process(_ context.Context, resp *scrapemate.Response) (any, [
 	domReviews, ok := resp.Meta["dom_reviews"].([]DOMReview)
 	if ok && len(domReviews) > 0 {
 		convertedReviews := ConvertDOMReviewsToReviews(domReviews)
-		entry.UserReviewsExtended = append(entry.UserReviewsExtended, convertedReviews...)
+
+		deduped := dedupeDOMReviewsAgainstPrimary(entry.UserReviews, convertedReviews)
+		if len(deduped) != len(convertedReviews) {
+			log.Printf("DOM reviews: dropped %d of %d already present in user_reviews",
+				len(convertedReviews)-len(deduped), len(convertedReviews))
+		}
+
+		entry.UserReviewsExtended = append(entry.UserReviewsExtended, deduped...)
 	}
 
 	if j.ExtractEmail && entry.IsWebsiteValidForEmail() {

--- a/gmaps/reviews.go
+++ b/gmaps/reviews.go
@@ -325,6 +325,7 @@ func generateRandomID(length int) (string, error) {
 
 // DOMReview represents a review extracted from the DOM
 type DOMReview struct {
+	ReviewID                string
 	AuthorName              string
 	AuthorURL               string
 	ProfilePicture          string
@@ -338,7 +339,8 @@ type DOMReview struct {
 func ConvertDOMReviewsToReviews(domReviews []DOMReview) []Review {
 	reviews := make([]Review, 0, len(domReviews))
 
-	for _, dr := range domReviews {
+	for i := range domReviews {
+		dr := &domReviews[i]
 		review := Review{
 			Name:           dr.AuthorName,
 			ProfilePicture: dr.ProfilePicture,
@@ -346,13 +348,113 @@ func ConvertDOMReviewsToReviews(domReviews []DOMReview) []Review {
 			Description:    dr.Text,
 			When:           dr.RelativeTimeDescription,
 			Images:         dr.Images,
+			ReviewID:       dr.ReviewID,
 		}
+
 		if review.Name != "" {
 			reviews = append(reviews, review)
 		}
 	}
 
 	return reviews
+}
+
+// dedupeDOMReviewsAgainstPrimary drops DOM reviews that are already present in the
+// primary reviews. Matching is by review id only, an empty id is never a duplicate.
+func dedupeDOMReviewsAgainstPrimary(primary, domReviews []Review) []Review {
+	seen := make(map[string]struct{}, len(primary))
+
+	for i := range primary {
+		if primary[i].ReviewID != "" {
+			seen[primary[i].ReviewID] = struct{}{}
+		}
+	}
+
+	if len(seen) == 0 {
+		return domReviews
+	}
+
+	kept := make([]Review, 0, len(domReviews))
+	withID := 0
+
+	for i := range domReviews {
+		if domReviews[i].ReviewID != "" {
+			withID++
+
+			if _, dup := seen[domReviews[i].ReviewID]; dup {
+				continue
+			}
+		}
+
+		kept = append(kept, domReviews[i])
+	}
+
+	if withID > 0 && len(kept) == len(domReviews) {
+		log.Printf("DOM review ids matched none of %d primary ids", len(seen))
+	}
+
+	return kept
+}
+
+func decodeDOMReviews(raw []any) []DOMReview {
+	decoded := make([]DOMReview, 0, len(raw))
+
+	for _, rawReview := range raw {
+		reviewMap, ok := rawReview.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		review := DOMReview{}
+		if v, ok := reviewMap["review_id"].(string); ok {
+			review.ReviewID = v
+		}
+
+		if v, ok := reviewMap["author_name"].(string); ok {
+			review.AuthorName = v
+		}
+
+		if v, ok := reviewMap["author_url"].(string); ok {
+			review.AuthorURL = v
+		}
+
+		if v, ok := reviewMap["profile_picture"].(string); ok {
+			review.ProfilePicture = v
+		}
+
+		// Playwright decodes whole JS numbers as int, fractional ones as float64.
+		switch v := reviewMap["rating"].(type) {
+		case int:
+			review.Rating = v
+		case float64:
+			review.Rating = int(v)
+		}
+
+		// The rating selectors also match non-star aria-labels, e.g. "12 reviews".
+		if review.Rating < 1 || review.Rating > 5 {
+			review.Rating = 0
+		}
+
+		if v, ok := reviewMap["relative_time_description"].(string); ok {
+			review.RelativeTimeDescription = v
+		}
+
+		if v, ok := reviewMap["text"].(string); ok {
+			review.Text = v
+		}
+
+		if v, ok := reviewMap["images"].([]interface{}); ok {
+			for _, img := range v {
+				if imgStr, ok := img.(string); ok {
+					review.Images = append(review.Images, imgStr)
+				}
+			}
+		}
+
+		decoded = append(decoded, review)
+	}
+
+	return decoded
 }
 
 // extractReviewsFromPage extracts reviews directly from the page DOM
@@ -469,6 +571,10 @@ func extractReviewsFromPage(ctx context.Context, page scrapemate.BrowserPage) ([
 
 				for (const element of reviewElements) {
 					try {
+						// The card carries the id, unless the selector matched a wrapper
+						const reviewId = element.getAttribute('data-review-id') ||
+							element.querySelector('[data-review-id]')?.getAttribute('data-review-id') || '';
+
 						// Author name - comprehensive selectors
 						const userSelectors = [
 							'.d4r55',           // Primary name class
@@ -587,6 +693,7 @@ func extractReviewsFromPage(ctx context.Context, page scrapemate.BrowserPage) ([
 
 						if (userName && (text || rating > 0)) {
 							reviews.push({
+								review_id: reviewId,
 								author_name: userName,
 								author_url: userUrl,
 								profile_picture: profilePic,
@@ -613,65 +720,29 @@ func extractReviewsFromPage(ctx context.Context, page scrapemate.BrowserPage) ([
 		} else if reviewsJSON != nil {
 			rawReviews, ok := reviewsJSON.([]any)
 			if ok {
-				for _, rawReview := range rawReviews {
-					reviewMap, ok := rawReview.(map[string]interface{})
-					if !ok {
-						continue
-					}
+				decoded := decodeDOMReviews(rawReviews)
 
-					review := DOMReview{}
-					if v, ok := reviewMap["author_name"].(string); ok {
-						review.AuthorName = v
-					}
-
-					if v, ok := reviewMap["author_url"].(string); ok {
-						review.AuthorURL = v
-					}
-
-					if v, ok := reviewMap["profile_picture"].(string); ok {
-						review.ProfilePicture = v
-					}
-
-					if v, ok := reviewMap["rating"].(float64); ok {
-						review.Rating = int(v)
-					}
-
-					if v, ok := reviewMap["relative_time_description"].(string); ok {
-						review.RelativeTimeDescription = v
-					}
-
-					if v, ok := reviewMap["text"].(string); ok {
-						review.Text = v
-					}
-
-					if v, ok := reviewMap["images"].([]interface{}); ok {
-						for _, img := range v {
-							if imgStr, ok := img.(string); ok {
-								review.Images = append(review.Images, imgStr)
-							}
-						}
-					}
-
+				for i := range decoded {
 					// Add if unique (check by author name and text prefix)
 					isDuplicate := false
 
-					for _, existing := range reviews {
-						if existing.AuthorName == review.AuthorName {
-							if existing.Text == review.Text {
+					for j := range reviews {
+						if reviews[j].AuthorName == decoded[i].AuthorName {
+							if reviews[j].Text == decoded[i].Text {
 								isDuplicate = true
 								break
 							}
 
-							if len(existing.Text) > 20 && len(review.Text) > 20 &&
-								existing.Text[:20] == review.Text[:20] {
+							if len(reviews[j].Text) > 20 && len(decoded[i].Text) > 20 &&
+								reviews[j].Text[:20] == decoded[i].Text[:20] {
 								isDuplicate = true
 								break
 							}
 						}
 					}
 
-					if !isDuplicate && review.AuthorName != "" {
-						reviews = append(reviews, review)
+					if !isDuplicate && decoded[i].AuthorName != "" {
+						reviews = append(reviews, decoded[i])
 					}
 				}
 			}


### PR DESCRIPTION
When the review RPC is blocked and the scraper falls back to DOM extraction, every entry written to `user_reviews_extended` has `Rating=0`, `review_id=""` and `source=""`, only the name, text, images and the relative `When` string have data. So the extended reviews can't be used for anything rating-based and can't be joined against `user_reviews`.

## Symptom

```
Browser-based RPC fetch failed: fetch error: HTTP 403, trying HTTP
RPC fetch failed, will try DOM extraction: .../maps/rpc/listugcposts?...: unexpected status code: 403
Attempting DOM-based review extraction
DOM extraction completed: 10 reviews found
```

All 10 entries per place land with those fields zeroed. The counts look healthy, which makes the degradation easy to miss. Reproduced against `v1.17.2-1419d5d` (digest `sha256:33c1ec397acbb3038515b5854cb8cea22ab7131a9ecb4b14995e5e982144e755`), two real places, `-depth 1 -lang en -extra-reviews`.

## Root cause

The rating is read using a `float64` type assertion (`reviews.go:635` before this PR):

```go
if v, ok := reviewMap["rating"].(float64); ok {
    review.Rating = int(v)
}
```

but playwright-go returns integral JS numbers as Go `int` (`parseValue`, `js_handle.go:104-113` in v0.6100.0):

```go
if v, ok := vMap["n"]; ok {
    if math.Ceil(v.(float64))-v.(float64) == 0 {
        return int(v.(float64))
    }
    return v.(float64)
}
```

The extraction script `Math.round`s the rating before pushing it, so the value's always an integer and the assertion fails 100% of the time. `review_id` and `source` just never got extracted on this path.

## What this PR changes

- The rating decode now accepts `int` and `float64`. The JS side is untouched.
- `review_id` is read from the card's `data-review-id` attribute and carried through to `Review.ReviewID`.
- With ids populated, extended entries are deduplicated against `user_reviews`: on two live test places every primary review reappeared in the extended set (matched heuristically before the fix, confirmed by id identity after, 8/8 per place). Dropping those leaves the genuinely new reviews (10 -> 2 per place). Empty ids never match. Note this changes output for anyone summing both columns (18 -> 10 per place).
- Decoded ratings are bounded to 1-5, anything out of range reads as unread (0).
- If DOM and primary review IDs ever stop overlapping entirely, the dedup logs one line instead of failing silently.
- Tests cover the decode edges, the converter, the dedup,.

- The switch to index-based loops isn't a style choice, gocritic's rangeValCopy trips once the struct passes 128 bytes.

## Known issues NOT fixed here

- The `listugcposts` 403 itself: this improves the fallback's output, it does not restore the RPC path. Diagnosis is in progress, will follow separately.
- `AuthorURL` is extracted by the DOM script but dropped by the converter.
- Extended descriptions stay truncated: the cross-attempt dedup keeps the first (collapsed) copy of a body instead of the longest.
## Verification

`make lint`, `go build ./...`, `go test -count=1 ./...`, `gofmt -s -l gmaps/` all clean. Live run against the pinned image with the patched binary, same places and flags: extended entries went from all-zeroed to ratings 1-5 (observed 5, 2, 5, 5, read, not defaulted), non-empty ids, relative times verbatim. Primary reviews unchanged. `posted_at_unix_micros` / `published_at` stay zero on purpose, the panel carries no absolute timestamp and nothing is fabricated.

## Related

- #315 reported the same failure mode, this fixes the degraded fallback output, not the 403 itself.
- #272 introduced the extended review fields this PR populates.
