### PR TITLE
feat: show live scrape progress in web UI

### DIFF
--- a/exiter/exiter.go
+++ b/exiter/exiter.go
@@ -11,6 +11,7 @@ type Exiter interface {
 	IncrSeedCompleted(int)
 	IncrPlacesFound(int)
 	IncrPlacesCompleted(int)
+	Progress() (placesFound, placesCompleted int)
 	Run(context.Context)
 }
 
@@ -79,6 +80,13 @@ func (e *exiter) IncrPlacesCompleted(val int) {
 		default:
 		}
 	}
+}
+
+func (e *exiter) Progress() (placesFound, placesCompleted int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.placesFound, e.placesCompleted
 }
 
 func (e *exiter) Run(ctx context.Context) {

--- a/runner/webrunner/webrunner.go
+++ b/runner/webrunner/webrunner.go
@@ -29,7 +29,16 @@ type webrunner struct {
 	svc       *web.Service
 	cfg       *runner.Config
 	setupMate func(context.Context, io.Writer, *web.Job) (mateRunner, error)
+
+	// newExiter builds the per-job exit monitor. Nil means exiter.New.
+	newExiter func() exiter.Exiter
+
+	// progressInterval is how often job progress is persisted while scraping.
+	// Zero means defaultProgressInterval.
+	progressInterval time.Duration
 }
+
+const defaultProgressInterval = 2 * time.Second
 
 type mateRunner interface {
 	Start(context.Context, ...scrapemate.IJob) error
@@ -139,9 +148,15 @@ func (w *webrunner) work(ctx context.Context) error {
 
 // trackProgress periodically copies the exit monitor's counters onto the job
 // and persists them, so the web UI (which polls /jobs) can show live progress.
-// It stops on its own once the job's context is done.
+// It returns once ctx is done. It writes job without synchronisation, so the
+// caller must not touch job until this has returned.
 func (w *webrunner) trackProgress(ctx context.Context, job *web.Job, exitMonitor exiter.Exiter) {
-	ticker := time.NewTicker(2 * time.Second)
+	interval := w.progressInterval
+	if interval <= 0 {
+		interval = defaultProgressInterval
+	}
+
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
@@ -215,7 +230,13 @@ func (w *webrunner) scrapeJob(ctx context.Context, job *web.Job) error {
 	}
 
 	dedup := deduper.New()
-	exitMonitor := exiter.New()
+
+	newExiter := w.newExiter
+	if newExiter == nil {
+		newExiter = exiter.New
+	}
+
+	exitMonitor := newExiter()
 
 	seedJobs, err := runner.CreateSeedJobs(
 		job.Data.FastMode,
@@ -266,12 +287,25 @@ func (w *webrunner) scrapeJob(ctx context.Context, job *web.Job) error {
 		exitMonitor.SetCancelFunc(cancel)
 
 		go exitMonitor.Run(mateCtx)
-		go w.trackProgress(mateCtx, job, exitMonitor)
+
+		// The progress tracker owns job for as long as it runs, so cancel()
+		// alone is not enough to touch job again: it only signals, and a tick
+		// already in flight would persist the stale "working" status over the
+		// final one. Wait for the tracker to exit before writing job again.
+		progressDone := make(chan struct{})
+
+		go func() {
+			defer close(progressDone)
+
+			w.trackProgress(mateCtx, job, exitMonitor)
+		}()
 
 		err = mate.Start(mateCtx, seedJobs...)
-		if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
-			cancel()
 
+		cancel()
+		<-progressDone
+
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 			err2 := w.svc.Update(ctx, job)
 			if err2 != nil {
 				log.Printf("failed to update job status: %v", err2)
@@ -279,8 +313,6 @@ func (w *webrunner) scrapeJob(ctx context.Context, job *web.Job) error {
 
 			return err
 		}
-
-		cancel()
 	}
 
 	job.Status = web.StatusOK

--- a/runner/webrunner/webrunner.go
+++ b/runner/webrunner/webrunner.go
@@ -137,6 +137,34 @@ func (w *webrunner) work(ctx context.Context) error {
 	}
 }
 
+// trackProgress periodically copies the exit monitor's counters onto the job
+// and persists them, so the web UI (which polls /jobs) can show live progress.
+// It stops on its own once the job's context is done.
+func (w *webrunner) trackProgress(ctx context.Context, job *web.Job, exitMonitor exiter.Exiter) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			found, completed := exitMonitor.Progress()
+
+			if found == job.Data.PlacesFound && completed == job.Data.PlacesCompleted {
+				continue
+			}
+
+			job.Data.PlacesFound = found
+			job.Data.PlacesCompleted = completed
+
+			if err := w.svc.Update(ctx, job); err != nil {
+				log.Printf("failed to update job progress for %s: %v", job.ID, err)
+			}
+		}
+	}
+}
+
 func (w *webrunner) scrapeJob(ctx context.Context, job *web.Job) error {
 	job.Status = web.StatusWorking
 
@@ -238,6 +266,7 @@ func (w *webrunner) scrapeJob(ctx context.Context, job *web.Job) error {
 		exitMonitor.SetCancelFunc(cancel)
 
 		go exitMonitor.Run(mateCtx)
+		go w.trackProgress(mateCtx, job, exitMonitor)
 
 		err = mate.Start(mateCtx, seedJobs...)
 		if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {

--- a/runner/webrunner/webrunner_test.go
+++ b/runner/webrunner/webrunner_test.go
@@ -4,9 +4,11 @@ package webrunner
 import (
 	"context"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/gosom/google-maps-scraper/exiter"
 	"github.com/gosom/google-maps-scraper/runner"
 	"github.com/gosom/google-maps-scraper/web"
 	"github.com/gosom/scrapemate"
@@ -62,11 +64,82 @@ func TestScrapeJobMarksOKBeforeClosingMate(t *testing.T) {
 	}
 }
 
+// The progress tracker runs concurrently with the scrape and persists the job
+// on a ticker, so it must be fully stopped before scrapeJob writes the final
+// status. Otherwise a tick still in flight commits the stale "working" status
+// afterwards and the job looks stuck at "working" forever in the UI.
+func TestScrapeJobWaitsForProgressTrackerBeforeFinishing(t *testing.T) {
+	t.Parallel()
+
+	repo := &memoryJobRepo{workingUpdateDelay: 300 * time.Millisecond}
+	svc := web.NewService(repo, t.TempDir())
+	job := web.Job{
+		ID:     "job-progress",
+		Name:   "coffee",
+		Date:   time.Now().UTC(),
+		Status: web.StatusPending,
+		Data: web.JobData{
+			Keywords: []string{"coffee"},
+			Lang:     "en",
+			Zoom:     15,
+			Lat:      "37.7749",
+			Lon:      "-122.4194",
+			FastMode: true,
+			Radius:   1000,
+			Depth:    10,
+			MaxTime:  time.Minute,
+		},
+	}
+
+	if err := svc.Create(context.Background(), &job); err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+
+	w := &webrunner{
+		svc:              svc,
+		cfg:              &runner.Config{DataFolder: t.TempDir(), Concurrency: 1},
+		progressInterval: time.Millisecond,
+		// Report ever-changing progress so every tick actually persists.
+		newExiter: func() exiter.Exiter { return &countingExiter{} },
+		setupMate: func(_ context.Context, _ io.Writer, _ *web.Job) (mateRunner, error) {
+			// Outlive many progress ticks so one is mid-flight at the end.
+			return fakeMate{startDelay: 50 * time.Millisecond}, nil
+		},
+	}
+
+	if err := w.scrapeJob(context.Background(), &job); err != nil {
+		t.Fatalf("scrape job: %v", err)
+	}
+
+	repo.sealAfterScrape()
+
+	// Give any tracker that outlived scrapeJob time to commit a stale write.
+	time.Sleep(600 * time.Millisecond)
+
+	if repo.sawLateUpdate() {
+		t.Error("progress tracker wrote the job after scrapeJob returned: it can clobber the final status")
+	}
+
+	got, err := svc.Get(context.Background(), job.ID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+
+	if got.Status != web.StatusOK {
+		t.Errorf("final status = %q, want %q", got.Status, web.StatusOK)
+	}
+}
+
 type fakeMate struct {
-	onClose func()
+	onClose    func()
+	startDelay time.Duration
 }
 
 func (m fakeMate) Start(context.Context, ...scrapemate.IJob) error {
+	if m.startDelay > 0 {
+		time.Sleep(m.startDelay)
+	}
+
 	return nil
 }
 
@@ -78,15 +151,54 @@ func (m fakeMate) Close() error {
 	return nil
 }
 
+// countingExiter reports a progress value that changes on every read, so the
+// tracker always has something new to persist.
+type countingExiter struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (e *countingExiter) SetSeedCount(int)                 {}
+func (e *countingExiter) SetCancelFunc(context.CancelFunc) {}
+func (e *countingExiter) IncrSeedCompleted(int)            {}
+func (e *countingExiter) IncrPlacesFound(int)              {}
+func (e *countingExiter) IncrPlacesCompleted(int)          {}
+func (e *countingExiter) Run(ctx context.Context)          { <-ctx.Done() }
+
+func (e *countingExiter) Progress() (int, int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.n++
+
+	return 100, e.n
+}
+
 type memoryJobRepo struct {
+	mu   sync.Mutex
 	jobs map[string]web.Job
+
+	// workingUpdateDelay simulates a slow in-flight progress write: the job is
+	// snapshotted when Update is called but committed only after the delay, so
+	// a tracker write started before the scrape ended can still land after the
+	// final status write.
+	workingUpdateDelay time.Duration
+
+	sealed     bool
+	lateUpdate bool
 }
 
 func (r *memoryJobRepo) Get(_ context.Context, id string) (web.Job, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	return r.jobs[id], nil
 }
 
 func (r *memoryJobRepo) Create(_ context.Context, job *web.Job) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if r.jobs == nil {
 		r.jobs = make(map[string]web.Job)
 	}
@@ -97,11 +209,18 @@ func (r *memoryJobRepo) Create(_ context.Context, job *web.Job) error {
 }
 
 func (r *memoryJobRepo) Delete(_ context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	delete(r.jobs, id)
+
 	return nil
 }
 
 func (r *memoryJobRepo) Select(_ context.Context, params web.SelectParams) ([]web.Job, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	jobs := make([]web.Job, 0, len(r.jobs))
 
 	for id := range r.jobs {
@@ -115,6 +234,38 @@ func (r *memoryJobRepo) Select(_ context.Context, params web.SelectParams) ([]we
 }
 
 func (r *memoryJobRepo) Update(_ context.Context, job *web.Job) error {
-	r.jobs[job.ID] = *job
+	snapshot := *job
+
+	// Only progress writes are slow, so the final status write cannot simply
+	// outwait them.
+	if r.workingUpdateDelay > 0 && snapshot.Status == web.StatusWorking {
+		time.Sleep(r.workingUpdateDelay)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.sealed {
+		r.lateUpdate = true
+	}
+
+	r.jobs[snapshot.ID] = snapshot
+
 	return nil
+}
+
+// sealAfterScrape marks the point where scrapeJob has returned, so any later
+// write is recorded as a leak.
+func (r *memoryJobRepo) sealAfterScrape() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.sealed = true
+}
+
+func (r *memoryJobRepo) sawLateUpdate() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.lateUpdate
 }

--- a/web/job.go
+++ b/web/job.go
@@ -73,6 +73,11 @@ type JobData struct {
 	ExtraReviews bool          `json:"extra_reviews"`
 	MaxTime      time.Duration `json:"max_time"`
 	Proxies      []string      `json:"proxies"`
+
+	// PlacesFound and PlacesCompleted are runtime progress counters,
+	// updated periodically while the job is working so the UI can show progress.
+	PlacesFound     int `json:"places_found"`
+	PlacesCompleted int `json:"places_completed"`
 }
 
 func (d *JobData) Validate() error {

--- a/web/static/templates/index.html
+++ b/web/static/templates/index.html
@@ -136,6 +136,7 @@
                             <th>Job Name</th>
                             <th>Job Date</th>
                             <th>Status</th>
+                            <th>Progress</th>
                             <th>Actions</th>
                         </tr>
                     </thead>

--- a/web/static/templates/job_row.html
+++ b/web/static/templates/job_row.html
@@ -6,6 +6,15 @@
         <span class="status-indicator status-{{.Status}}">{{.Status}}</span>
     </td>
     <td>
+        {{ if eq .Status "working" }}
+            {{ if gt .Data.PlacesFound 0 }}
+                {{.Data.PlacesCompleted}} / {{.Data.PlacesFound}}
+            {{ else }}
+                searching&hellip;
+            {{ end }}
+        {{ end }}
+    </td>
+    <td>
         {{ if eq .Status "ok" }}
             <a href="/download?id={{.ID}}" download class="button download-button">Download</a>
         {{ end }}

--- a/web/static/templates/job_rows.html
+++ b/web/static/templates/job_rows.html
@@ -7,6 +7,15 @@
         <span class="status-indicator status-{{.Status}}">{{.Status}}</span>
     </td>
     <td>
+        {{ if eq .Status "working" }}
+            {{ if gt .Data.PlacesFound 0 }}
+                {{.Data.PlacesCompleted}} / {{.Data.PlacesFound}}
+            {{ else }}
+                searching&hellip;
+            {{ end }}
+        {{ end }}
+    </td>
+    <td>
         {{ if eq .Status "ok" }}
             <button type="button" class="button view-button"
                     hx-get="/view?id={{.ID}}"

--- a/web/web.go
+++ b/web/web.go
@@ -514,6 +514,10 @@ func (s *Server) apiScrape(w http.ResponseWriter, r *http.Request) {
 	// convert to seconds
 	newJob.Data.MaxTime *= time.Second
 
+	// Progress counters are owned by the runner, not by the caller.
+	newJob.Data.PlacesFound = 0
+	newJob.Data.PlacesCompleted = 0
+
 	err = newJob.Validate()
 	if err != nil {
 		ans := apiError{


### PR DESCRIPTION
## Summary
- Adds a live "Progress" column to the web UI job table, showing `found/completed` place counts while a job is `working`.
- Uses the existing `exiter.Exiter`'s internal counters (already tracked for exit-on-inactivity) via a new `Progress()` getter, polled every 2s and persisted to the job record.
- No behavior change for jobs in a terminal state (`ok`/`failed`) or for the CLI/database/lambda runners — this only touches the web runner's job table and polling loop, which already refreshes every 10s via htmx.

## Motivation
Long-running jobs (e.g. 100+ places) gave no feedback beyond "working", making it hard to tell whether a job was progressing or stuck. This surfaces the counters scrapemate already tracks internally.

## Test plan
- [x] `go build .` succeeds
- [x] Manually ran jobs of varying sizes (40-112 places) through the web UI and confirmed the Progress column updates live (e.g. `1/40` -> `39/40` -> completion) every ~2-3s
- [x] Confirmed jobs with 0 results and completed/failed jobs render an empty Progress cell as before
